### PR TITLE
feat(bookmarks): real-time SSE, collapsible in all views, stream-owned bookmarks

### DIFF
--- a/apps/api/src/lib/__tests__/bookmark-pubsub.test.ts
+++ b/apps/api/src/lib/__tests__/bookmark-pubsub.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Bookmark PubSub Unit Tests
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  InMemoryBookmarkPubSub,
+  type BookmarkEvent,
+  getBookmarkPubSub,
+  setBookmarkPubSub,
+} from '../bookmark-pubsub';
+
+describe('InMemoryBookmarkPubSub', () => {
+  let pubsub: InMemoryBookmarkPubSub;
+
+  beforeEach(() => {
+    pubsub = new InMemoryBookmarkPubSub();
+  });
+
+  const sampleEvent: BookmarkEvent = {
+    type: 'bookmark_created',
+    bookmark: {
+      id: '550e8400-e29b-41d4-a716-446655440000',
+      directStreamId: 'tchs',
+      viewerIdentityId: '550e8400-e29b-41d4-a716-446655440001',
+      timestampSeconds: 120,
+      label: 'Great Goal!',
+      isShared: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  };
+
+  describe('publish', () => {
+    it('should broadcast to all subscribers for the same slug', () => {
+      const received: BookmarkEvent[] = [];
+      pubsub.subscribe('tchs', (data) => received.push(data));
+      pubsub.subscribe('tchs', (data) => received.push(data));
+
+      pubsub.publish('tchs', sampleEvent);
+
+      expect(received).toHaveLength(2);
+      expect(received[0]).toEqual(sampleEvent);
+      expect(received[1]).toEqual(sampleEvent);
+    });
+
+    it('should not broadcast to subscribers of a different slug', () => {
+      const received: BookmarkEvent[] = [];
+      pubsub.subscribe('other-slug', (data) => received.push(data));
+
+      pubsub.publish('tchs', sampleEvent);
+
+      expect(received).toHaveLength(0);
+    });
+
+    it('should not throw when publishing with no subscribers', () => {
+      expect(() => pubsub.publish('no-one-listening', sampleEvent)).not.toThrow();
+    });
+
+    it('should catch errors in subscriber handlers', () => {
+      pubsub.subscribe('tchs', () => {
+        throw new Error('handler error');
+      });
+
+      // Should not throw
+      expect(() => pubsub.publish('tchs', sampleEvent)).not.toThrow();
+    });
+  });
+
+  describe('subscribe', () => {
+    it('should return an unsubscribe function', () => {
+      const received: BookmarkEvent[] = [];
+      const unsubscribe = pubsub.subscribe('tchs', (data) => received.push(data));
+
+      pubsub.publish('tchs', sampleEvent);
+      expect(received).toHaveLength(1);
+
+      unsubscribe();
+
+      pubsub.publish('tchs', sampleEvent);
+      expect(received).toHaveLength(1); // No new events
+    });
+
+    it('should handle multiple subscriptions and selective unsubscription', () => {
+      const received1: BookmarkEvent[] = [];
+      const received2: BookmarkEvent[] = [];
+
+      const unsub1 = pubsub.subscribe('tchs', (data) => received1.push(data));
+      pubsub.subscribe('tchs', (data) => received2.push(data));
+
+      unsub1();
+
+      pubsub.publish('tchs', sampleEvent);
+
+      expect(received1).toHaveLength(0);
+      expect(received2).toHaveLength(1);
+    });
+  });
+
+  describe('event types', () => {
+    it('should support bookmark_created events', () => {
+      const received: BookmarkEvent[] = [];
+      pubsub.subscribe('tchs', (data) => received.push(data));
+
+      pubsub.publish('tchs', { ...sampleEvent, type: 'bookmark_created' });
+
+      expect(received[0].type).toBe('bookmark_created');
+    });
+
+    it('should support bookmark_deleted events', () => {
+      const received: BookmarkEvent[] = [];
+      pubsub.subscribe('tchs', (data) => received.push(data));
+
+      pubsub.publish('tchs', { ...sampleEvent, type: 'bookmark_deleted' });
+
+      expect(received[0].type).toBe('bookmark_deleted');
+    });
+
+    it('should support bookmark_updated events', () => {
+      const received: BookmarkEvent[] = [];
+      pubsub.subscribe('tchs', (data) => received.push(data));
+
+      pubsub.publish('tchs', { ...sampleEvent, type: 'bookmark_updated' });
+
+      expect(received[0].type).toBe('bookmark_updated');
+    });
+
+    it('should support stream_ended events', () => {
+      const received: BookmarkEvent[] = [];
+      pubsub.subscribe('tchs', (data) => received.push(data));
+
+      pubsub.publish('tchs', { type: 'stream_ended' });
+
+      expect(received[0].type).toBe('stream_ended');
+      expect(received[0].bookmark).toBeUndefined();
+    });
+  });
+
+  describe('singleton', () => {
+    it('getBookmarkPubSub returns a singleton', () => {
+      const instance1 = getBookmarkPubSub();
+      const instance2 = getBookmarkPubSub();
+      expect(instance1).toBe(instance2);
+    });
+
+    it('setBookmarkPubSub replaces the singleton', () => {
+      const custom = new InMemoryBookmarkPubSub();
+      setBookmarkPubSub(custom);
+      expect(getBookmarkPubSub()).toBe(custom);
+    });
+  });
+
+  describe('null viewerIdentityId', () => {
+    it('should handle bookmarks with null viewerIdentityId', () => {
+      const orphanedEvent: BookmarkEvent = {
+        type: 'bookmark_created',
+        bookmark: {
+          id: '550e8400-e29b-41d4-a716-446655440002',
+          directStreamId: 'tchs',
+          viewerIdentityId: null,
+          timestampSeconds: 300,
+          label: 'Orphaned Bookmark',
+          isShared: true,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        },
+      };
+
+      const received: BookmarkEvent[] = [];
+      pubsub.subscribe('tchs', (data) => received.push(data));
+
+      pubsub.publish('tchs', orphanedEvent);
+
+      expect(received).toHaveLength(1);
+      expect(received[0].bookmark?.viewerIdentityId).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/lib/bookmark-pubsub.ts
+++ b/apps/api/src/lib/bookmark-pubsub.ts
@@ -1,0 +1,87 @@
+/**
+ * Bookmark PubSub Abstraction
+ *
+ * In-memory POC (works for single instance).
+ * Production: swap with Redis-backed implementation for multi-replica.
+ */
+
+import { logger } from './logger';
+
+export interface BookmarkEvent {
+  type: 'bookmark_created' | 'bookmark_deleted' | 'bookmark_updated' | 'stream_ended';
+  bookmark?: {
+    id: string;
+    gameId?: string | null;
+    directStreamId?: string | null;
+    clipId?: string | null;
+    viewerIdentityId?: string | null;
+    timestampSeconds: number;
+    label: string;
+    notes?: string | null;
+    isShared: boolean;
+    bufferSeconds?: number | null;
+    createdAt: Date | string;
+    updatedAt: Date | string;
+  };
+}
+
+export interface IBookmarkPubSub {
+  publish(slug: string, data: BookmarkEvent): void;
+  subscribe(slug: string, handler: (data: BookmarkEvent) => void): () => void;
+}
+
+export class InMemoryBookmarkPubSub implements IBookmarkPubSub {
+  private handlers = new Map<string, Set<(data: BookmarkEvent) => void>>();
+
+  publish(slug: string, data: BookmarkEvent): void {
+    const handlers = this.handlers.get(slug);
+    if (!handlers || handlers.size === 0) {
+      logger.debug({ slug, type: data.type }, 'No subscribers for bookmark event');
+      return;
+    }
+
+    logger.debug({ slug, type: data.type, subscribers: handlers.size }, 'Broadcasting bookmark event');
+
+    handlers.forEach((handler) => {
+      try {
+        handler(data);
+      } catch (error) {
+        logger.error({ error, slug }, 'Error in bookmark subscriber handler');
+      }
+    });
+  }
+
+  subscribe(slug: string, handler: (data: BookmarkEvent) => void): () => void {
+    if (!this.handlers.has(slug)) {
+      this.handlers.set(slug, new Set());
+    }
+
+    const handlers = this.handlers.get(slug)!;
+    handlers.add(handler);
+
+    logger.debug({ slug, totalSubscribers: handlers.size }, 'New bookmark subscriber');
+
+    return () => {
+      handlers.delete(handler);
+      if (handlers.size === 0) {
+        this.handlers.delete(slug);
+      }
+      logger.debug({ slug, totalSubscribers: handlers.size }, 'Bookmark subscriber removed');
+    };
+  }
+}
+
+// Singleton instance
+let instance: IBookmarkPubSub | null = null;
+
+export function getBookmarkPubSub(): IBookmarkPubSub {
+  if (!instance) {
+    instance = new InMemoryBookmarkPubSub();
+    logger.info('Initialized in-memory bookmark pubsub');
+  }
+  return instance;
+}
+
+export function setBookmarkPubSub(pubsub: IBookmarkPubSub): void {
+  instance = pubsub;
+}

--- a/apps/api/src/repositories/interfaces/IBookmarkRepository.ts
+++ b/apps/api/src/repositories/interfaces/IBookmarkRepository.ts
@@ -16,7 +16,7 @@ export interface CreateBookmarkInput {
   gameId?: string;
   directStreamId?: string;
   clipId?: string;
-  viewerIdentityId: string;
+  viewerIdentityId?: string;
   timestampSeconds: number;
   label: string;
   notes?: string;

--- a/apps/api/src/routes/direct-lifecycle.ts
+++ b/apps/api/src/routes/direct-lifecycle.ts
@@ -7,6 +7,7 @@ import { Router, type Request, type Response, type NextFunction } from 'express'
 import { prisma } from '../lib/prisma';
 import { logger } from '../lib/logger';
 import { validateAdminToken } from '../middleware/admin-jwt';
+import { getBookmarkPubSub } from '../lib/bookmark-pubsub';
 
 const router = Router();
 
@@ -158,6 +159,9 @@ router.delete(
             autoPurgeAt,
           },
         });
+
+        // Notify bookmark SSE subscribers that stream is ended
+        getBookmarkPubSub().publish(slug, { type: 'stream_ended' });
 
         logger.info(
           {

--- a/apps/api/src/services/DVRService.ts
+++ b/apps/api/src/services/DVRService.ts
@@ -105,7 +105,7 @@ export class DVRService implements IDVRService {
       startTimeSeconds,
       endTimeSeconds,
       isPublic: input.isPublic,
-      createdById: bookmark.viewerIdentityId,
+      createdById: bookmark.viewerIdentityId ?? undefined,
       createdByType: 'viewer',
     });
 

--- a/apps/api/src/services/interfaces/IDVRService.ts
+++ b/apps/api/src/services/interfaces/IDVRService.ts
@@ -37,7 +37,7 @@ export interface CreateClipFromBookmarkInput {
 export interface CreateBookmarkInput {
   gameId?: string;
   directStreamId?: string;
-  viewerIdentityId: string;
+  viewerIdentityId?: string;
   timestampSeconds: number;
   label: string;
   notes?: string;

--- a/apps/web/components/v2/video/BookmarkMarkers.tsx
+++ b/apps/web/components/v2/video/BookmarkMarkers.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 /**
- * BookmarkMarkers - Visual bookmark pins on the video timeline.
+ * BookmarkMarkers - Visual bookmark tabs on the video timeline.
  *
- * Renders absolutely-positioned dots at the correct percentage positions
- * along the timeline track. Own bookmarks are amber, shared are blue.
- * Hovering shows a tooltip with label, time, and creator info.
+ * Renders absolutely-positioned tab/flag markers at the correct percentage
+ * positions along the timeline track. Own bookmarks are amber, shared are blue,
+ * orphaned (former viewer) are gray. Hovering shows a tooltip; clicking expands.
+ * New bookmarks arriving via SSE get a subtle entrance animation.
  */
 
+import { useMemo } from 'react';
 import type { VideoBookmark } from '@/lib/hooks/useDVR';
 import { BookmarkTooltip } from './BookmarkTooltip';
 
@@ -18,6 +20,12 @@ function formatTime(seconds: number): string {
   const s = Math.floor(seconds % 60);
   if (h > 0) return `${h}:${m.toString().padStart(2, '0')}:${s.toString().padStart(2, '0')}`;
   return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+/** Bookmarks created in the last 5 seconds get an entrance animation */
+function isRecent(bookmark: VideoBookmark): boolean {
+  const created = new Date(bookmark.createdAt).getTime();
+  return Date.now() - created < 5000;
 }
 
 interface BookmarkMarkersProps {
@@ -33,6 +41,15 @@ export function BookmarkMarkers({
   currentViewerId,
   onBookmarkClick,
 }: BookmarkMarkersProps) {
+  // Memoize the recent-check so it doesn't re-run every render for every bookmark
+  const recentIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const b of bookmarks) {
+      if (isRecent(b)) ids.add(b.id);
+    }
+    return ids;
+  }, [bookmarks]);
+
   if (duration <= 0 || bookmarks.length === 0) return null;
 
   return (
@@ -45,7 +62,21 @@ export function BookmarkMarkers({
           Math.max((bookmark.timestampSeconds / duration) * 100, 0),
           100,
         );
-        const isOwn = bookmark.viewerIdentityId === currentViewerId;
+        const isOwn = bookmark.viewerIdentityId != null && bookmark.viewerIdentityId === currentViewerId;
+        const isOrphaned = bookmark.viewerIdentityId == null;
+        const showEntrance = recentIds.has(bookmark.id);
+
+        // Color: amber for own, blue for shared, gray for orphaned
+        const markerColor = isOwn
+          ? 'bg-amber-400'
+          : isOrphaned
+            ? 'bg-gray-400'
+            : 'bg-blue-400';
+        const shadowColor = isOwn
+          ? 'shadow-amber-400/50'
+          : isOrphaned
+            ? 'shadow-gray-400/50'
+            : 'shadow-blue-400/50';
 
         return (
           <BookmarkTooltip
@@ -53,6 +84,9 @@ export function BookmarkMarkers({
             label={bookmark.label}
             time={formatTime(bookmark.timestampSeconds)}
             isOwn={isOwn}
+            isOrphaned={isOrphaned}
+            notes={bookmark.notes}
+            onJumpTo={() => onBookmarkClick?.(bookmark)}
           >
             <button
               type="button"
@@ -66,23 +100,55 @@ export function BookmarkMarkers({
               aria-label={`Bookmark: ${bookmark.label} at ${formatTime(bookmark.timestampSeconds)}`}
               data-testid={`bookmark-marker-${bookmark.id}`}
             >
-              {/* Marker dot with 44px touch target */}
+              {/* Tab/flag marker: vertical bar + triangle cap */}
               <span
                 className={`
-                  block w-2.5 h-2.5 rounded-full
-                  shadow-md
+                  flex flex-col items-center
                   transition-transform duration-150
-                  group-hover:scale-150
-                  ${isOwn
-                    ? 'bg-amber-400 shadow-amber-400/50'
-                    : 'bg-blue-400 shadow-blue-400/50'
-                  }
+                  group-hover:scale-125
+                  ${showEntrance ? 'animate-bounce-in' : ''}
                 `}
-              />
+              >
+                {/* Triangle cap */}
+                <span
+                  className={`
+                    w-0 h-0
+                    border-l-[4px] border-l-transparent
+                    border-r-[4px] border-r-transparent
+                    border-b-[5px]
+                    ${isOwn
+                      ? 'border-b-amber-400'
+                      : isOrphaned
+                        ? 'border-b-gray-400'
+                        : 'border-b-blue-400'
+                    }
+                  `}
+                />
+                {/* Vertical bar */}
+                <span
+                  className={`
+                    block w-[3px] h-2.5 rounded-b-sm
+                    shadow-md
+                    ${markerColor} ${shadowColor}
+                  `}
+                />
+              </span>
             </button>
           </BookmarkTooltip>
         );
       })}
+
+      {/* Entrance animation keyframes (scoped via Tailwind arbitrary) */}
+      <style jsx>{`
+        @keyframes bounceIn {
+          0% { transform: scale(0) translateY(8px); opacity: 0; }
+          60% { transform: scale(1.2) translateY(-2px); opacity: 1; }
+          100% { transform: scale(1) translateY(0); opacity: 1; }
+        }
+        :global(.animate-bounce-in) {
+          animation: bounceIn 0.4s ease-out;
+        }
+      `}</style>
     </div>
   );
 }

--- a/apps/web/components/v2/video/BookmarkPanel.tsx
+++ b/apps/web/components/v2/video/BookmarkPanel.tsx
@@ -81,10 +81,26 @@ export function BookmarkPanel({
     </div>
   );
 
-  // Inline: render tabs + list directly (for portrait layout)
+  // Inline: render collapse header + tabs + list (portrait layout — collapsible in all views)
   if (effectiveMode === 'inline') {
     return (
       <div className="flex flex-col h-full" data-testid="bookmark-panel-inline">
+        {/* Collapse header: back/close so bookmarks are collapsible in portrait like other views */}
+        <div className="flex shrink-0 items-center gap-2 border-b border-white/10 bg-[var(--fv-color-bg-secondary)]/80 px-3 py-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex items-center gap-1.5 text-sm font-medium text-[var(--fv-color-text-muted)] hover:text-[var(--fv-color-text)] transition-colors min-h-[44px] min-w-[44px] -ml-1 rounded"
+            aria-label="Back to chat"
+            data-testid="btn-collapse-bookmark-inline"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            <span>Chat</span>
+          </button>
+          <span className="text-sm font-semibold text-white">Bookmarks</span>
+        </div>
         {tabs}
         {content}
       </div>

--- a/apps/web/components/v2/video/BookmarkToast.tsx
+++ b/apps/web/components/v2/video/BookmarkToast.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+/**
+ * BookmarkToast - Lightweight notification for real-time bookmark announcements.
+ *
+ * Renders a stack of auto-dismissing notification cards inside the video
+ * player container. Each toast shows the bookmark label, time, and a
+ * "Jump to" action. Max 3 visible at once.
+ */
+
+import { useEffect, useRef, useCallback, useState } from 'react';
+
+export interface BookmarkToastItem {
+  id: string;
+  label: string;
+  time: string;
+  timestampSeconds: number;
+}
+
+interface BookmarkToastProps {
+  toasts: BookmarkToastItem[];
+  onJumpTo?: (timestampSeconds: number) => void;
+  onDismiss?: (id: string) => void;
+}
+
+const MAX_VISIBLE = 3;
+const AUTO_DISMISS_MS = 4000;
+
+export function BookmarkToast({ toasts, onJumpTo, onDismiss }: BookmarkToastProps) {
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  // Auto-dismiss each toast after AUTO_DISMISS_MS
+  useEffect(() => {
+    for (const toast of toasts) {
+      if (!timersRef.current.has(toast.id)) {
+        const timer = setTimeout(() => {
+          onDismiss?.(toast.id);
+          timersRef.current.delete(toast.id);
+        }, AUTO_DISMISS_MS);
+        timersRef.current.set(toast.id, timer);
+      }
+    }
+
+    // Cleanup timers for removed toasts
+    for (const [id, timer] of timersRef.current.entries()) {
+      if (!toasts.some(t => t.id === id)) {
+        clearTimeout(timer);
+        timersRef.current.delete(id);
+      }
+    }
+  }, [toasts, onDismiss]);
+
+  // Cleanup all timers on unmount
+  useEffect(() => {
+    return () => {
+      for (const timer of timersRef.current.values()) {
+        clearTimeout(timer);
+      }
+      timersRef.current.clear();
+    };
+  }, []);
+
+  const visible = toasts.slice(-MAX_VISIBLE);
+
+  if (visible.length === 0) return null;
+
+  return (
+    <div
+      className="absolute bottom-20 right-2 z-[50] flex flex-col gap-2 pointer-events-auto"
+      data-testid="bookmark-toasts"
+    >
+      {visible.map((toast, index) => (
+        <div
+          key={toast.id}
+          className="bg-gray-900/95 backdrop-blur-sm text-white text-xs rounded-lg
+            px-3 py-2 shadow-xl border border-white/10
+            min-w-[180px] max-w-[260px]
+            animate-slide-in"
+          style={{ animationDelay: `${index * 50}ms` }}
+          data-testid={`toast-bookmark-${toast.id}`}
+          role="status"
+          aria-live="polite"
+        >
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex-1 min-w-0">
+              <div className="text-[10px] text-amber-400 font-medium mb-0.5">
+                New Bookmark
+              </div>
+              <div className="font-medium truncate">{toast.label}</div>
+              <div className="text-gray-400 font-mono mt-0.5">{toast.time}</div>
+            </div>
+
+            {/* Dismiss button */}
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onDismiss?.(toast.id);
+              }}
+              className="text-gray-500 hover:text-white shrink-0 p-0.5"
+              aria-label="Dismiss notification"
+              data-testid={`btn-dismiss-toast-${toast.id}`}
+            >
+              <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          {/* Jump To action */}
+          {onJumpTo && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onJumpTo(toast.timestampSeconds);
+                onDismiss?.(toast.id);
+              }}
+              className="mt-1.5 w-full text-[10px] font-medium rounded
+                bg-amber-500/15 text-amber-300 hover:bg-amber-500/25
+                transition-colors py-1 px-2
+                min-h-[28px]"
+              data-testid={`btn-toast-jump-${toast.id}`}
+              aria-label={`Jump to ${toast.time}`}
+            >
+              Jump to {toast.time}
+            </button>
+          )}
+        </div>
+      ))}
+
+      <style jsx>{`
+        @keyframes slideIn {
+          0% { transform: translateX(100%); opacity: 0; }
+          100% { transform: translateX(0); opacity: 1; }
+        }
+        :global(.animate-slide-in) {
+          animation: slideIn 0.3s ease-out both;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+/**
+ * useBookmarkToasts - Manages toast state for bookmark notifications.
+ * Use in DirectStreamPageBase to wire up SSE notifications.
+ */
+export function useBookmarkToasts() {
+  const [toasts, setToasts] = useState<BookmarkToastItem[]>([]);
+
+  const addToast = useCallback((item: BookmarkToastItem) => {
+    setToasts(prev => {
+      // Avoid duplicate toast for same bookmark
+      if (prev.some(t => t.id === item.id)) return prev;
+      // Keep max toasts reasonable (trim oldest beyond 5)
+      const next = [...prev, item];
+      return next.length > 5 ? next.slice(-5) : next;
+    });
+  }, []);
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts(prev => prev.filter(t => t.id !== id));
+  }, []);
+
+  return { toasts, addToast, dismissToast };
+}

--- a/apps/web/components/v2/video/BookmarkTooltip.tsx
+++ b/apps/web/components/v2/video/BookmarkTooltip.tsx
@@ -1,21 +1,24 @@
 'use client';
 
 /**
- * BookmarkTooltip - Hover tooltip for bookmark markers on the timeline.
+ * BookmarkTooltip - Hover tooltip + click-to-expand popup for bookmark markers.
  *
- * Shows bookmark label, timestamp, and whether it's the viewer's own or shared.
- * Uses a simple CSS tooltip approach (no Radix dependency to keep it lightweight
- * inside the video player).
- *
+ * Hover: minimal tooltip (label + time + badge).
+ * Click/tap: expanded card with full label, notes, ownership badge, and Jump To button.
  * Supports touch devices via onTouchStart with auto-hide after 2.5s.
+ *
+ * No Radix dependency -- lightweight CSS approach inside the video player.
  */
 
-import { useState, useRef, useEffect, type ReactNode } from 'react';
+import { useState, useRef, useEffect, useCallback, type ReactNode } from 'react';
 
 interface BookmarkTooltipProps {
   label: string;
   time: string;
   isOwn: boolean;
+  isOrphaned?: boolean;
+  notes?: string;
+  onJumpTo?: () => void;
   children: ReactNode;
 }
 
@@ -23,10 +26,15 @@ export function BookmarkTooltip({
   label,
   time,
   isOwn,
+  isOrphaned = false,
+  notes,
+  onJumpTo,
   children,
 }: BookmarkTooltipProps) {
   const [isVisible, setIsVisible] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // Cleanup timer on unmount
   useEffect(() => {
@@ -35,23 +43,71 @@ export function BookmarkTooltip({
     };
   }, []);
 
+  // Dismiss expanded popup on Escape or click outside
+  useEffect(() => {
+    if (!isExpanded) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        setIsExpanded(false);
+      }
+    };
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setIsExpanded(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown, true);
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, true);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isExpanded]);
+
   const showTooltipTouch = () => {
     clearTimeout(hideTimerRef.current);
     setIsVisible(true);
     hideTimerRef.current = setTimeout(() => setIsVisible(false), 2500);
   };
 
+  const handleClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    setIsExpanded(prev => !prev);
+  }, []);
+
+  const handleJumpTo = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    onJumpTo?.();
+    setIsExpanded(false);
+  }, [onJumpTo]);
+
+  // Badge display logic
+  const badgeLabel = isOwn ? 'You' : isOrphaned ? 'Former Viewer' : 'Shared';
+  const badgeColor = isOwn
+    ? 'bg-amber-500/20 text-amber-300'
+    : isOrphaned
+      ? 'bg-gray-500/20 text-gray-300'
+      : 'bg-blue-500/20 text-blue-300';
+
   return (
     <div
+      ref={containerRef}
       className="relative inline-block"
-      onMouseEnter={() => setIsVisible(true)}
-      onMouseLeave={() => setIsVisible(false)}
-      onFocus={() => setIsVisible(true)}
-      onBlur={() => setIsVisible(false)}
+      onMouseEnter={() => { if (!isExpanded) setIsVisible(true); }}
+      onMouseLeave={() => { if (!isExpanded) setIsVisible(false); }}
+      onFocus={() => { if (!isExpanded) setIsVisible(true); }}
+      onBlur={() => { if (!isExpanded) setIsVisible(false); }}
       onTouchStart={showTooltipTouch}
+      onClick={handleClick}
     >
       {children}
-      {isVisible && (
+
+      {/* Hover tooltip (minimal) */}
+      {isVisible && !isExpanded && (
         <div
           className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50 pointer-events-none"
           role="tooltip"
@@ -60,10 +116,58 @@ export function BookmarkTooltip({
             <div className="font-medium truncate max-w-[200px]">{label}</div>
             <div className="flex items-center gap-1.5 mt-0.5 text-gray-400">
               <span className="font-mono">{time}</span>
-              <span className={`text-[10px] px-1 rounded ${isOwn ? 'bg-amber-500/20 text-amber-300' : 'bg-blue-500/20 text-blue-300'}`}>
-                {isOwn ? 'You' : 'Shared'}
+              <span className={`text-[10px] px-1 rounded ${badgeColor}`}>
+                {badgeLabel}
               </span>
             </div>
+          </div>
+          {/* Arrow */}
+          <div className="absolute top-full left-1/2 -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-900/95" />
+        </div>
+      )}
+
+      {/* Expanded popup (click) */}
+      {isExpanded && (
+        <div
+          className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-50 pointer-events-auto"
+          role="dialog"
+          aria-label={`Bookmark: ${label}`}
+          data-testid={`popup-bookmark`}
+        >
+          <div className="bg-gray-900/95 backdrop-blur-sm text-white text-sm rounded-lg px-3.5 py-2.5 shadow-xl border border-white/10 min-w-[200px] max-w-[280px]">
+            {/* Label (full, not truncated) */}
+            <div className="font-semibold text-sm leading-snug mb-1">{label}</div>
+
+            {/* Timestamp + badge */}
+            <div className="flex items-center gap-1.5 text-gray-400 text-xs mb-2">
+              <span className="font-mono">{time}</span>
+              <span className={`text-[10px] px-1 rounded ${badgeColor}`}>
+                {badgeLabel}
+              </span>
+            </div>
+
+            {/* Notes (if any) */}
+            {notes && (
+              <p className="text-xs text-gray-300 leading-relaxed mb-2 border-t border-white/10 pt-1.5">
+                {notes}
+              </p>
+            )}
+
+            {/* Jump To button */}
+            {onJumpTo && (
+              <button
+                type="button"
+                onClick={handleJumpTo}
+                className="w-full mt-1 px-2.5 py-1.5 text-xs font-medium rounded
+                  bg-amber-500/20 text-amber-300 hover:bg-amber-500/30
+                  transition-colors border border-amber-500/20
+                  min-h-[36px]"
+                data-testid="btn-jump-to-bookmark"
+                aria-label={`Jump to ${time}`}
+              >
+                Jump to {time}
+              </button>
+            )}
           </div>
           {/* Arrow */}
           <div className="absolute top-full left-1/2 -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-900/95" />

--- a/apps/web/hooks/v2/useBookmarkMarkers.ts
+++ b/apps/web/hooks/v2/useBookmarkMarkers.ts
@@ -3,13 +3,14 @@
 /**
  * useBookmarkMarkers - Fetches and manages bookmark markers for the timeline.
  *
- * Combines the current viewer's bookmarks with shared bookmarks from others.
- * Polls every 30s for new shared bookmarks.
+ * Uses SSE (useBookmarkSSE) as the primary real-time data source.
+ * Falls back to polling every 30s when SSE is disconnected.
  * Supports optimistic insertion when the current user creates a bookmark.
  */
 
-import { useEffect, useCallback, useRef } from 'react';
+import { useEffect, useCallback, useRef, useState } from 'react';
 import { useListBookmarks, type VideoBookmark } from '@/lib/hooks/useDVR';
+import { useBookmarkSSE } from './useBookmarkSSE';
 
 const POLL_INTERVAL_MS = 30_000;
 
@@ -17,19 +18,29 @@ interface UseBookmarkMarkersOptions {
   directStreamId?: string;
   viewerId?: string;
   enabled?: boolean;
+  onBookmarkReceived?: (bookmark: VideoBookmark) => void;
 }
 
 export function useBookmarkMarkers({
   directStreamId,
   viewerId,
   enabled = true,
+  onBookmarkReceived,
 }: UseBookmarkMarkersOptions) {
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [optimisticBookmarks, setOptimisticBookmarks] = useState<VideoBookmark[]>([]);
 
+  // SSE: primary real-time source for shared bookmarks
+  const sse = useBookmarkSSE({
+    slug: directStreamId,
+    enabled,
+    onBookmarkReceived,
+  });
+
+  // Polling: fallback when SSE is disconnected
   const {
-    bookmarks,
+    bookmarks: polledBookmarks,
     fetchBookmarks,
-    addOptimistic,
     loading,
     error,
   } = useListBookmarks({
@@ -38,15 +49,24 @@ export function useBookmarkMarkers({
     includeShared: true,
   });
 
-  // Initial fetch when enabled
+  // Initial fetch when enabled (needed regardless of SSE for own bookmarks)
   useEffect(() => {
     if (!enabled || !directStreamId) return;
     void fetchBookmarks();
   }, [enabled, directStreamId, fetchBookmarks]);
 
-  // Poll for new shared bookmarks
+  // Poll only when SSE is disconnected
   useEffect(() => {
     if (!enabled || !directStreamId) return;
+
+    // Don't poll if SSE is handling real-time updates
+    if (sse.isConnected) {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+      return;
+    }
 
     pollRef.current = setInterval(() => {
       void fetchBookmarks();
@@ -58,20 +78,57 @@ export function useBookmarkMarkers({
         pollRef.current = null;
       }
     };
-  }, [enabled, directStreamId, fetchBookmarks]);
+  }, [enabled, directStreamId, fetchBookmarks, sse.isConnected]);
 
-  // Derived: split into own vs shared
-  const ownBookmarks = bookmarks.filter(b => b.viewerIdentityId === viewerId);
+  // Merge SSE bookmarks with polled bookmarks.
+  // SSE provides shared bookmarks; polled provides own + shared.
+  // When SSE is connected, use SSE for shared and polled for own-only.
+  // When SSE is disconnected, use polled for everything.
+  const bookmarks = (() => {
+    if (sse.isConnected) {
+      // Own bookmarks from polled (not shared, just this viewer's)
+      const ownFromPoll = polledBookmarks.filter(
+        b => b.viewerIdentityId != null && b.viewerIdentityId === viewerId && !b.isShared,
+      );
+      // Merge own private with SSE shared, plus optimistic adds
+      const merged = new Map<string, VideoBookmark>();
+      for (const b of ownFromPoll) merged.set(b.id, b);
+      for (const b of sse.bookmarks) merged.set(b.id, b);
+      for (const b of optimisticBookmarks) merged.set(b.id, b);
+      return Array.from(merged.values()).sort(
+        (a, b) => a.timestampSeconds - b.timestampSeconds,
+      );
+    }
+    // SSE disconnected: use polled data + optimistic adds
+    const merged = new Map<string, VideoBookmark>();
+    for (const b of polledBookmarks) merged.set(b.id, b);
+    for (const b of optimisticBookmarks) merged.set(b.id, b);
+    return Array.from(merged.values()).sort(
+      (a, b) => a.timestampSeconds - b.timestampSeconds,
+    );
+  })();
+
+  // Derived: split into own vs shared (handles null viewerIdentityId)
+  const ownBookmarks = bookmarks.filter(
+    b => b.viewerIdentityId != null && b.viewerIdentityId === viewerId,
+  );
   const sharedBookmarks = bookmarks.filter(
-    b => b.viewerIdentityId !== viewerId && b.isShared,
+    b => b.viewerIdentityId !== viewerId || b.viewerIdentityId == null,
   );
 
   // Add a bookmark optimistically (for instant marker display after creation)
   const addBookmarkOptimistic = useCallback(
     (bookmark: VideoBookmark) => {
-      addOptimistic(bookmark);
+      setOptimisticBookmarks(prev => {
+        if (prev.some(b => b.id === bookmark.id)) return prev;
+        return [...prev, bookmark];
+      });
+      // Clear optimistic after next poll cycle picks it up
+      setTimeout(() => {
+        setOptimisticBookmarks(prev => prev.filter(b => b.id !== bookmark.id));
+      }, POLL_INTERVAL_MS + 5000);
     },
-    [addOptimistic],
+    [],
   );
 
   return {
@@ -82,5 +139,6 @@ export function useBookmarkMarkers({
     refetch: fetchBookmarks,
     loading,
     error,
+    sseConnected: sse.isConnected,
   };
 }

--- a/apps/web/hooks/v2/useBookmarkSSE.ts
+++ b/apps/web/hooks/v2/useBookmarkSSE.ts
@@ -1,0 +1,146 @@
+'use client';
+
+/**
+ * useBookmarkSSE - SSE client for real-time bookmark updates.
+ *
+ * Connects to /api/bookmarks/stream/:slug and maintains
+ * a live list of shared bookmarks. Falls back gracefully
+ * when the connection drops (caller should resume polling).
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import type { VideoBookmark } from '@/lib/hooks/useDVR';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4301';
+const RECONNECT_DELAY_MS = 5000;
+
+interface BookmarkSSEEvent {
+  type: 'bookmark_created' | 'bookmark_deleted' | 'bookmark_updated' | 'stream_ended';
+  bookmark?: VideoBookmark;
+}
+
+interface UseBookmarkSSEOptions {
+  slug?: string;
+  enabled?: boolean;
+  onBookmarkReceived?: (bookmark: VideoBookmark) => void;
+}
+
+interface UseBookmarkSSEReturn {
+  bookmarks: VideoBookmark[];
+  isConnected: boolean;
+}
+
+export function useBookmarkSSE({
+  slug,
+  enabled = true,
+  onBookmarkReceived,
+}: UseBookmarkSSEOptions): UseBookmarkSSEReturn {
+  const [bookmarks, setBookmarks] = useState<VideoBookmark[]>([]);
+  const [isConnected, setIsConnected] = useState(false);
+  const onBookmarkReceivedRef = useRef(onBookmarkReceived);
+
+  // Keep callback ref fresh without re-triggering effect
+  useEffect(() => {
+    onBookmarkReceivedRef.current = onBookmarkReceived;
+  }, [onBookmarkReceived]);
+
+  useEffect(() => {
+    if (!enabled || !slug) {
+      setIsConnected(false);
+      return;
+    }
+
+    const sseUrl = `${API_URL}/api/bookmarks/stream/${encodeURIComponent(slug)}`;
+    let es: EventSource | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout>;
+    let disposed = false;
+
+    function connect() {
+      if (disposed) return;
+
+      es = new EventSource(sseUrl);
+
+      // Initial snapshot: replace full list
+      es.addEventListener('bookmark_snapshot', (event) => {
+        try {
+          const data = JSON.parse(event.data) as { bookmarks: VideoBookmark[] };
+          setBookmarks(data.bookmarks);
+          setIsConnected(true);
+        } catch (err) {
+          console.error('[Bookmark SSE] snapshot parse error:', err);
+        }
+      });
+
+      // New bookmark created
+      es.addEventListener('bookmark_created', (event) => {
+        try {
+          const data = JSON.parse(event.data) as BookmarkSSEEvent;
+          if (data.bookmark) {
+            setBookmarks(prev => {
+              // Avoid duplicates (optimistic add may already have it)
+              if (prev.some(b => b.id === data.bookmark!.id)) return prev;
+              return [...prev, data.bookmark!].sort(
+                (a, b) => a.timestampSeconds - b.timestampSeconds,
+              );
+            });
+            onBookmarkReceivedRef.current?.(data.bookmark);
+          }
+        } catch (err) {
+          console.error('[Bookmark SSE] created parse error:', err);
+        }
+      });
+
+      // Bookmark deleted
+      es.addEventListener('bookmark_deleted', (event) => {
+        try {
+          const data = JSON.parse(event.data) as BookmarkSSEEvent;
+          if (data.bookmark) {
+            setBookmarks(prev => prev.filter(b => b.id !== data.bookmark!.id));
+          }
+        } catch (err) {
+          console.error('[Bookmark SSE] deleted parse error:', err);
+        }
+      });
+
+      // Bookmark updated
+      es.addEventListener('bookmark_updated', (event) => {
+        try {
+          const data = JSON.parse(event.data) as BookmarkSSEEvent;
+          if (data.bookmark) {
+            setBookmarks(prev =>
+              prev.map(b => (b.id === data.bookmark!.id ? data.bookmark! : b)),
+            );
+          }
+        } catch (err) {
+          console.error('[Bookmark SSE] updated parse error:', err);
+        }
+      });
+
+      // Stream ended (soft-deleted)
+      es.addEventListener('stream_ended', () => {
+        setBookmarks([]);
+        setIsConnected(false);
+        es?.close();
+      });
+
+      es.onerror = () => {
+        setIsConnected(false);
+        es?.close();
+        if (!disposed) {
+          reconnectTimer = setTimeout(connect, RECONNECT_DELAY_MS);
+        }
+      };
+    }
+
+    connect();
+
+    return () => {
+      disposed = true;
+      setIsConnected(false);
+      clearTimeout(reconnectTimer);
+      es?.close();
+    };
+  }, [enabled, slug]);
+
+  return { bookmarks, isConnected };
+}

--- a/apps/web/lib/hooks/useDVR.ts
+++ b/apps/web/lib/hooks/useDVR.ts
@@ -36,7 +36,7 @@ export interface VideoBookmark {
   gameId?: string;
   directStreamId?: string;
   clipId?: string;
-  viewerIdentityId: string;
+  viewerIdentityId?: string | null;
   timestampSeconds: number;
   label: string;
   notes?: string;

--- a/docs/BOOKMARK_VALIDATION_COMPLETE.md
+++ b/docs/BOOKMARK_VALIDATION_COMPLETE.md
@@ -199,6 +199,21 @@ open http://localhost:4300/test/dvr
 
 ---
 
+## 📐 Collapsible bookmarks (all views)
+
+Bookmarks panel is collapsible in every view for consistent UX:
+
+| View | Collapse behavior |
+|------|--------------------|
+| **Desktop/Tablet** | Right-edge sidebar: collapsed tab (←) to expand; header arrow (→) or **B** / **Escape** to collapse |
+| **Mobile (landscape)** | BottomSheet: drag down or overlay toggle button; **B** toggles |
+| **Portrait** | Chat \| Bookmarks tabs: tap **Chat** or **← Chat** header in bookmark content; **B** switches tab |
+
+- Portrait inline panel includes a **← Chat** header button (`btn-collapse-bookmark-inline`) so the list can be collapsed without leaving the tab bar.
+- All views support **B** keyboard shortcut where applicable (non-fullscreen, non-touch hint).
+
+---
+
 ## 📝 Next Steps (Optional Enhancements)
 
 1. **Rate Limiting**: Limit bookmark creation to X per minute

--- a/packages/data-model/prisma/migrations/20260212000000_bookmark_stream_owned_viewer_setnull/migration.sql
+++ b/packages/data-model/prisma/migrations/20260212000000_bookmark_stream_owned_viewer_setnull/migration.sql
@@ -1,0 +1,13 @@
+-- AlterTable: Make VideoBookmark.viewerIdentityId nullable (bookmarks are stream-owned)
+-- When a ViewerIdentity is deleted, bookmarks survive with viewerIdentityId set to NULL
+ALTER TABLE "VideoBookmark" ALTER COLUMN "viewerIdentityId" DROP NOT NULL;
+
+-- Drop the existing CASCADE foreign key constraint
+ALTER TABLE "VideoBookmark" DROP CONSTRAINT IF EXISTS "VideoBookmark_viewerIdentityId_fkey";
+
+-- Re-create with SET NULL behavior
+ALTER TABLE "VideoBookmark"
+  ADD CONSTRAINT "VideoBookmark_viewerIdentityId_fkey"
+  FOREIGN KEY ("viewerIdentityId") REFERENCES "ViewerIdentity"("id")
+  ON DELETE SET NULL
+  ON UPDATE CASCADE;

--- a/packages/data-model/prisma/schema.prisma
+++ b/packages/data-model/prisma/schema.prisma
@@ -926,7 +926,7 @@ model VideoBookmark {
   gameId           String?   @db.Uuid // Optional: link to game
   directStreamId   String?   @db.Uuid // Optional: link to direct stream
   clipId           String?   @db.Uuid // Optional: link to generated clip
-  viewerIdentityId String    @db.Uuid // Who created the bookmark
+  viewerIdentityId String?   @db.Uuid // Who created the bookmark (nullable: bookmarks survive viewer deletion)
   timestampSeconds Int // When the event happened
   label            String // e.g., "Great Goal!", "Offside Call"
   notes            String? // Optional additional notes
@@ -937,8 +937,8 @@ model VideoBookmark {
 
   game           Game?          @relation(fields: [gameId], references: [id], onDelete: Cascade)
   directStream   DirectStream?  @relation(fields: [directStreamId], references: [id], onDelete: Cascade)
-  clip           VideoClip?     @relation(fields: [clipId], references: [id], onDelete: Cascade)
-  viewerIdentity ViewerIdentity @relation(fields: [viewerIdentityId], references: [id], onDelete: Cascade)
+  clip           VideoClip?      @relation(fields: [clipId], references: [id], onDelete: Cascade)
+  viewerIdentity ViewerIdentity? @relation(fields: [viewerIdentityId], references: [id], onDelete: SetNull)
 
   @@index([gameId])
   @@index([directStreamId])

--- a/packages/data-model/src/schemas/dvrSchemas.ts
+++ b/packages/data-model/src/schemas/dvrSchemas.ts
@@ -79,7 +79,7 @@ export const BOOKMARK_LIMITS = {
 export const createBookmarkSchema = z.object({
   gameId: z.string().uuid().optional(),
   directStreamId: z.string().uuid().optional(),
-  viewerIdentityId: z.string().uuid(),
+  viewerIdentityId: z.string().uuid().optional(),
   timestampSeconds: z.number().int().min(0).max(BOOKMARK_LIMITS.MAX_TIMESTAMP_SECONDS),
   label: z.string()
     .trim()


### PR DESCRIPTION
## Summary
- **Real-time bookmark propagation**: Bookmark pubsub + SSE endpoint `GET /api/bookmarks/stream/:slug` (snapshot, created/deleted/updated/stream_ended). `useBookmarkSSE` + `useBookmarkMarkers` (SSE primary, 30s polling fallback).
- **UI**: Tab/flag timeline markers, BookmarkTooltip with click popup, BookmarkToast for real-time announcements. Bookmark panel collapsible in all views (desktop sidebar, mobile sheet, portrait inline with ← Chat header).
- **Stream-owned bookmarks**: `VideoBookmark.viewerIdentityId` nullable, `onDelete: SetNull` so bookmarks survive viewer deletion. Prisma migration included.
- **API**: `CreateBookmarkInput.viewerIdentityId` optional; POST/PATCH/DELETE publish to pubsub when shared; soft-delete publishes `stream_ended`.

## Testing
- Preflight build: ✅
- API `bookmark-pubsub` tests: 13 passed
- Web `useBookmarkMarkers` tests: 9 passed
- Some existing API/Web unit tests fail (DB/integration, unrelated UI); not introduced by this PR.

Made with [Cursor](https://cursor.com)