### PR TITLE
chore: gitignore test artifacts + Traklet update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,13 @@ prisma/migrations/
 # These directories contain backups and temporary files from devibe
 .devibe/
 .unvibe/
+
+# Veo PoC artifacts (contain a Mux stream key — never commit)
+veo-poc-output/
+
+# Playwright / test run output (generated — never commit)
+test-results/
+playwright-report/
+
+# Editor workspace files
+*.code-workspace

--- a/.traklet/config.md
+++ b/.traklet/config.md
@@ -1,0 +1,6 @@
+---
+adapter: github
+baseUrl: https://api.github.com
+project: YOLOVibeCode/fieldview-live
+tokenEnv: NEXT_PUBLIC_TRAKLET_GITHUB_TOKEN
+---

--- a/.traklet/settings.template.json
+++ b/.traklet/settings.template.json
@@ -1,0 +1,9 @@
+{
+  "user": { "email": "your.email@company.com", "name": "Your Name" },
+  "token": "paste-your-github-pat-here",
+  "adapter": "github",
+  "baseUrl": "https://api.github.com",
+  "project": "YOLOVibeCode/fieldview-live",
+  "position": "bottom-right",
+  "theme": "dark"
+}

--- a/.traklet/test-cases/account/TC-AP-001-viewer-account-page.md
+++ b/.traklet/test-cases/account/TC-AP-001-viewer-account-page.md
@@ -12,7 +12,7 @@ suite: account
 
 {traklet:section:objective}
 ## Objective
-`/account` shows purchases, profile, or entitlement summary when a viewer/owner session is present; handles anonymous state per design.
+`https://fieldview.live/account` shows purchases, profile, or entitlement summary when a viewer/owner session is present; handles anonymous state per design.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -22,9 +22,9 @@ suite: account
 
 {traklet:section:steps}
 ## Steps
-1. While logged in (any relevant viewer identity), open `/account`
+1. While logged in (any relevant viewer identity), open `https://fieldview.live/account`
 2. Verify list of accessible games/purchases or empty state
-3. Optional: anonymous user hits `/account` — redirect to login or marketing message?
+3. Optional: anonymous user hits `https://fieldview.live/account` — redirect to login or marketing message?
 {/traklet:section:steps}
 
 {traklet:section:expected-result}

--- a/.traklet/test-cases/account/TC-AP-002-viewer-profile-edit.md
+++ b/.traklet/test-cases/account/TC-AP-002-viewer-profile-edit.md
@@ -13,7 +13,7 @@ suite: account
 
 {traklet:section:objective}
 ## Objective
-Verify an authenticated viewer can edit their first/last name on the `/account` page, and that guest accounts have profile editing disabled.
+Verify an authenticated viewer can edit their first/last name on the `https://fieldview.live/account` page, and that guest accounts have profile editing disabled.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -23,7 +23,7 @@ Verify an authenticated viewer can edit their first/last name on the `/account` 
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/account`
+1. Navigate to `https://fieldview.live/account`
 2. Verify profile section shows current name and email
 3. Edit first name and last name fields
 4. Click save — verify `PATCH /api/public/viewer/{id}` is called

--- a/.traklet/test-cases/account/TC-AP-003-viewer-subscriptions-manage.md
+++ b/.traklet/test-cases/account/TC-AP-003-viewer-subscriptions-manage.md
@@ -13,7 +13,7 @@ suite: account
 
 {traklet:section:objective}
 ## Objective
-Verify the `/account` page shows active stream subscriptions and allows the viewer to unsubscribe.
+Verify the `https://fieldview.live/account` page shows active stream subscriptions and allows the viewer to unsubscribe.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -23,7 +23,7 @@ Verify the `/account` page shows active stream subscriptions and allows the view
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/account`
+1. Navigate to `https://fieldview.live/account`
 2. Verify Stream Subscriptions section loads (`GET /api/public/viewer/{id}/subscriptions`)
 3. Verify each subscription shows the stream name/slug
 4. Click "Unsubscribe" on a subscription

--- a/.traklet/test-cases/account/TC-AP-004-viewer-purchase-history.md
+++ b/.traklet/test-cases/account/TC-AP-004-viewer-purchase-history.md
@@ -13,7 +13,7 @@ suite: account
 
 {traklet:section:objective}
 ## Objective
-Verify the `/account` page shows the viewer's payment history with expandable receipt details.
+Verify the `https://fieldview.live/account` page shows the viewer's payment history with expandable receipt details.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -23,7 +23,7 @@ Verify the `/account` page shows the viewer's payment history with expandable re
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/account`
+1. Navigate to `https://fieldview.live/account`
 2. Verify Payment History section loads (`GET /api/public/viewer/{id}/purchases`)
 3. Verify each purchase shows game/stream name and date
 4. Click to expand a purchase receipt

--- a/.traklet/test-cases/account/TC-PR-001-password-reset-request.md
+++ b/.traklet/test-cases/account/TC-PR-001-password-reset-request.md
@@ -12,7 +12,7 @@ suite: account
 
 {traklet:section:objective}
 ## Objective
-Forgot-password flow delivers reset link (or error if unknown email) and `/reset-password` completes with new credential.
+Forgot-password flow delivers reset link (or error if unknown email) and `https://fieldview.live/reset-password` completes with new credential.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -23,10 +23,10 @@ Forgot-password flow delivers reset link (or error if unknown email) and `/reset
 
 {traklet:section:steps}
 ## Steps
-1. Open `/forgot-password`
+1. Open `https://fieldview.live/forgot-password`
 2. Submit owner email
 3. Open reset link token from email (or capture from dev mail sink)
-4. Set new password on `/reset-password`
+4. Set new password on `https://fieldview.live/reset-password`
 5. Login with new password (**TC-OA-001** path)
 {/traklet:section:steps}
 

--- a/.traklet/test-cases/account/TC-PR-002-password-reset-completion.md
+++ b/.traklet/test-cases/account/TC-PR-002-password-reset-completion.md
@@ -13,7 +13,7 @@ suite: account
 
 {traklet:section:objective}
 ## Objective
-Verify the `/reset-password` page validates the reset token, enforces password strength requirements, and allows setting a new password that works for subsequent login.
+Verify the `https://fieldview.live/reset-password` page validates the reset token, enforces password strength requirements, and allows setting a new password that works for subsequent login.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -24,7 +24,7 @@ Verify the `/reset-password` page validates the reset token, enforces password s
 
 {traklet:section:steps}
 ## Steps
-1. Click the reset link from the email (navigates to `/reset-password?token=...`)
+1. Click the reset link from the email (navigates to `https://fieldview.live/reset-password?token=...`)
 2. Verify token is validated (`GET /api/auth/password-reset/verify/{token}`)
 3. Verify password form appears with strength indicator and requirements checklist
 4. Enter a weak password — verify requirements checklist shows unmet criteria

--- a/.traklet/test-cases/admin-console/TC-CN-003-revenue-summary-loads.md
+++ b/.traklet/test-cases/admin-console/TC-CN-003-revenue-summary-loads.md
@@ -12,7 +12,7 @@ suite: admin-console
 
 {traklet:section:objective}
 ## Objective
-Console revenue report (`/admin/revenue` or equivalent) fetches aggregates; spot-check vs single known purchase total when feasible.
+Console revenue report (`https://fieldview.live/admin/revenue` or equivalent) fetches aggregates; spot-check vs single known purchase total when feasible.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}

--- a/.traklet/test-cases/admin-console/TC-CN-004-coupons-list-loads.md
+++ b/.traklet/test-cases/admin-console/TC-CN-004-coupons-list-loads.md
@@ -12,7 +12,7 @@ suite: admin-console
 
 {traklet:section:objective}
 ## Objective
-`/admin/coupons` (or current) loads for authorized admin; creating/editing coupons follows validation (exercise only in non-prod if risky).
+`https://fieldview.live/admin/coupons` (or current) loads for authorized admin; creating/editing coupons follows validation (exercise only in non-prod if risky).
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}

--- a/.traklet/test-cases/admin-console/TC-CN-005-search-no-results.md
+++ b/.traklet/test-cases/admin-console/TC-CN-005-search-no-results.md
@@ -23,7 +23,7 @@ Verify that searching for a query with no matches displays appropriate empty sta
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/admin/console`
+1. Navigate to `https://fieldview.live/admin/console`
 2. Enter a query guaranteed to have no matches (e.g. `zzz-nonexistent-12345@fake.test`)
 3. Click "Search" or press Enter
 4. Verify search completes without error (no error banner)

--- a/.traklet/test-cases/admin-console/TC-CN-006-search-by-phone.md
+++ b/.traklet/test-cases/admin-console/TC-CN-006-search-by-phone.md
@@ -24,7 +24,7 @@ Verify that searching by E.164 phone number returns matching viewer results with
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/admin/console`
+1. Navigate to `https://fieldview.live/admin/console`
 2. Enter a known E.164 phone number (e.g. `+15551234567`) in the search input
 3. Click "Search"
 4. Verify Viewers card shows at least one match

--- a/.traklet/test-cases/admin-console/TC-CN-007-purchase-timeline-detail.md
+++ b/.traklet/test-cases/admin-console/TC-CN-007-purchase-timeline-detail.md
@@ -26,7 +26,7 @@ Verify that clicking a purchase from search results navigates to the purchase de
 ## Steps
 1. From admin console, search for a known purchase (by email or ID)
 2. Click a purchase result row (has aria-label "View purchase {id}")
-3. Verify navigation to `/admin/purchases/{purchaseId}`
+3. Verify navigation to `https://fieldview.live/admin/purchases/{purchaseId}`
 4. Verify purchase info card shows:
    - Game title
    - Viewer email (masked for support_admin, full for super_admin)
@@ -35,7 +35,7 @@ Verify that clicking a purchase from search results navigates to the purchase de
    - Created date/time
 5. Verify Timeline card shows chronological events
 6. Verify each event shows description (bold), timestamp, and event type
-7. Click "Back" button — verify return to `/admin/console`
+7. Click "Back" button — verify return to `https://fieldview.live/admin/console`
 {/traklet:section:steps}
 
 {traklet:section:expected-result}

--- a/.traklet/test-cases/admin-console/TC-CN-008-game-audience-page.md
+++ b/.traklet/test-cases/admin-console/TC-CN-008-game-audience-page.md
@@ -25,7 +25,7 @@ Verify the game audience page displays purchasers, watchers, and purchase-to-wat
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/admin/owners/{ownerId}/games/{gameId}/audience`
+1. Navigate to `https://fieldview.live/admin/owners/{ownerId}/games/{gameId}/audience`
 2. Verify page header shows "Audience" with owner/game IDs
 3. Verify Purchasers card:
    - Shows "Purchase→watch conversion: X.X%"
@@ -34,7 +34,7 @@ Verify the game audience page displays purchasers, watchers, and purchase-to-wat
 4. Verify Watchers card:
    - Lists watchers with email, last watched date (or "—"), session count
    - Or shows "No watchers." empty state
-5. Click "Back" button — verify return to `/admin/console`
+5. Click "Back" button — verify return to `https://fieldview.live/admin/console`
 {/traklet:section:steps}
 
 {traklet:section:expected-result}

--- a/.traklet/test-cases/admin-console/TC-CN-009-create-coupon-percentage.md
+++ b/.traklet/test-cases/admin-console/TC-CN-009-create-coupon-percentage.md
@@ -24,7 +24,7 @@ Verify a superadmin can create a new percentage-based coupon via the create moda
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/admin/coupons`
+1. Navigate to `https://fieldview.live/admin/coupons`
 2. Click "Create Coupon" button
 3. Verify create modal appears
 4. Fill in fields:

--- a/.traklet/test-cases/admin-console/TC-CN-010-create-coupon-fixed-amount.md
+++ b/.traklet/test-cases/admin-console/TC-CN-010-create-coupon-fixed-amount.md
@@ -23,7 +23,7 @@ Verify a superadmin can create a fixed-amount (dollar) coupon, and that the disc
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/admin/coupons`
+1. Navigate to `https://fieldview.live/admin/coupons`
 2. Click "Create Coupon"
 3. Change Discount Type from "Percentage" to "Fixed Amount"
 4. Verify the value input label changes to "Amount Off ($)"

--- a/.traklet/test-cases/admin-console/TC-CN-011-disable-coupon.md
+++ b/.traklet/test-cases/admin-console/TC-CN-011-disable-coupon.md
@@ -24,7 +24,7 @@ Verify a superadmin can disable an active coupon via the Disable button, and tha
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/admin/coupons`
+1. Navigate to `https://fieldview.live/admin/coupons`
 2. Locate an active coupon row (green status badge)
 3. Click "Disable" button on that row
 4. Verify API call: `DELETE /api/admin/coupons/{couponId}` returns 204

--- a/.traklet/test-cases/admin-console/TC-CN-012-purchases-list-filtered.md
+++ b/.traklet/test-cases/admin-console/TC-CN-012-purchases-list-filtered.md
@@ -13,7 +13,7 @@ suite: admin-console
 
 {traklet:section:objective}
 ## Objective
-Verify the `/admin/purchases` page lists all purchases with date range, status, and org filters, showing payout breakdown (gross, fees, net) and pagination.
+Verify the `https://fieldview.live/admin/purchases` page lists all purchases with date range, status, and org filters, showing payout breakdown (gross, fees, net) and pagination.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -24,13 +24,13 @@ Verify the `/admin/purchases` page lists all purchases with date range, status, 
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/admin/purchases`
+1. Navigate to `https://fieldview.live/admin/purchases`
 2. Verify filter card loads with date range, status dropdown, org search input
 3. Verify table loads with purchases showing: date, viewer, game, status badge, gross, fees, net
 4. Apply status filter "paid" — verify table re-renders with only paid purchases
 5. Set a date range — click "Apply Filters" — verify filtered results
 6. Enter an org short name — apply — verify filtered by organization
-7. Click a purchase row — verify navigation to `/admin/purchases/:id` (existing detail page)
+7. Click a purchase row — verify navigation to `https://fieldview.live/admin/purchases/:id` (existing detail page)
 8. Test pagination with Previous/Next buttons
 9. Verify "Purchases" nav link appears in header alongside Console, Revenue, Coupons
 {/traklet:section:steps}

--- a/.traklet/test-cases/admin/TC-AD-001-admin-unlock.md
+++ b/.traklet/test-cases/admin/TC-AD-001-admin-unlock.md
@@ -24,7 +24,7 @@ Verify that the admin panel can be unlocked with the correct owner password and 
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to a direct stream page
+1. Navigate to `https://fieldview.live/direct/[slug]`
 2. Enter the owner password in the admin unlock form
 3. Submit the form
 4. Observe the admin panel state

--- a/.traklet/test-cases/admin/TC-AD-002-update-stream-url-from-event-admin.md
+++ b/.traklet/test-cases/admin/TC-AD-002-update-stream-url-from-event-admin.md
@@ -18,7 +18,7 @@ After **TC-AD-001**, producer can change playback URL / Mux asset for a nested d
 
 {traklet:section:prerequisites}
 ## Prerequisites
-- Unlocked admin panel on `/direct/...` event page
+- Unlocked admin panel on `https://fieldview.live/direct/...` event page
 - Test-safe HLS or Mux playback URL (may be stub in staging)
 {/traklet:section:prerequisites}
 

--- a/.traklet/test-cases/auth-admin/TC-AA-001-site-admin-login-mfa.md
+++ b/.traklet/test-cases/auth-admin/TC-AA-001-site-admin-login-mfa.md
@@ -13,7 +13,7 @@ suite: auth-admin
 
 {traklet:section:objective}
 ## Objective
-Verify console admin can authenticate including MFA/TOTP step and reach the admin console. Distinct from **TC-AD-001** (direct-stream producer unlock on `/direct/...`).
+Verify console admin can authenticate including MFA/TOTP step and reach the admin console. Distinct from **TC-AD-001** (direct-stream producer unlock on `https://fieldview.live/direct/...`).
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -24,10 +24,10 @@ Verify console admin can authenticate including MFA/TOTP step and reach the admi
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/admin/login` (or current admin entry URL)
+1. Navigate to `https://fieldview.live/admin/login` (or current admin entry URL)
 2. Submit primary credentials
 3. When prompted, enter MFA code
-4. Confirm arrival at console home (e.g. `/admin/console` or equivalent)
+4. Confirm arrival at console home (e.g. `https://fieldview.live/admin/console` or equivalent)
 {/traklet:section:steps}
 
 {traklet:section:expected-result}

--- a/.traklet/test-cases/auth-admin/TC-AA-003-login-invalid-credentials.md
+++ b/.traklet/test-cases/auth-admin/TC-AA-003-login-invalid-credentials.md
@@ -18,17 +18,17 @@ Verify that submitting incorrect credentials on the admin login page shows an er
 
 {traklet:section:prerequisites}
 ## Prerequisites
-- Admin login page accessible at `/admin/login`
+- Admin login page accessible at `https://fieldview.live/admin/login`
 - Known valid admin email (to test wrong password)
 {/traklet:section:prerequisites}
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/admin/login`
+1. Navigate to `https://fieldview.live/admin/login`
 2. Enter a valid admin email and an incorrect password
 3. Click "Sign in"
 4. Verify error banner appears with authentication failure message
-5. Verify URL remains on `/admin/login` (no redirect)
+5. Verify URL remains on `https://fieldview.live/admin/login` (no redirect)
 6. Verify no session token in localStorage
 7. Enter a completely unknown email and any password
 8. Click "Sign in"

--- a/.traklet/test-cases/auth-admin/TC-AA-004-session-logout-clears-token.md
+++ b/.traklet/test-cases/auth-admin/TC-AA-004-session-logout-clears-token.md
@@ -13,7 +13,7 @@ suite: auth-admin
 
 {traklet:section:objective}
 ## Objective
-Verify that clicking "Sign out" on any admin console page clears the session token from localStorage, emits a user update event, and redirects to `/admin/login`.
+Verify that clicking "Sign out" on any admin console page clears the session token from localStorage, emits a user update event, and redirects to `https://fieldview.live/admin/login`.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -23,20 +23,20 @@ Verify that clicking "Sign out" on any admin console page clears the session tok
 
 {traklet:section:steps}
 ## Steps
-1. Authenticate and navigate to `/admin/console`
+1. Authenticate and navigate to `https://fieldview.live/admin/console`
 2. Verify session token exists in localStorage
 3. Click "Sign out" button (desktop text or mobile icon)
-4. Verify redirect to `/admin/login`
+4. Verify redirect to `https://fieldview.live/admin/login`
 5. Verify session token is removed from localStorage
-6. Attempt to navigate directly to `/admin/console` via URL bar
-7. Verify redirect back to `/admin/login` (no stale session)
-8. Repeat from `/admin/revenue` and `/admin/coupons` — confirm logout works from every page
+6. Attempt to navigate directly to `https://fieldview.live/admin/console` via URL bar
+7. Verify redirect back to `https://fieldview.live/admin/login` (no stale session)
+8. Repeat from `https://fieldview.live/admin/revenue` and `https://fieldview.live/admin/coupons` — confirm logout works from every page
 {/traklet:section:steps}
 
 {traklet:section:expected-result}
 ## Expected Result
 - Sign out clears `adminSessionToken` from localStorage
-- Immediate redirect to `/admin/login`
+- Immediate redirect to `https://fieldview.live/admin/login`
 - Subsequent direct navigation to protected pages redirects to login
 - No flash of protected content before redirect
 {/traklet:section:expected-result}

--- a/.traklet/test-cases/auth-admin/TC-AA-005-unauthenticated-redirect.md
+++ b/.traklet/test-cases/auth-admin/TC-AA-005-unauthenticated-redirect.md
@@ -13,7 +13,7 @@ suite: auth-admin
 
 {traklet:section:objective}
 ## Objective
-Verify that all protected admin pages redirect unauthenticated users to `/admin/login` without leaking any admin data or rendering protected content.
+Verify that all protected admin pages redirect unauthenticated users to `https://fieldview.live/admin/login` without leaking any admin data or rendering protected content.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -24,25 +24,25 @@ Verify that all protected admin pages redirect unauthenticated users to `/admin/
 {traklet:section:steps}
 ## Steps
 1. Clear localStorage (or open incognito window)
-2. Navigate directly to `/admin/console`
-3. Verify redirect to `/admin/login`
-4. Navigate directly to `/admin/revenue`
-5. Verify redirect to `/admin/login`
-6. Navigate directly to `/admin/coupons`
-7. Verify redirect to `/admin/login`
-8. Navigate directly to `/admin/purchases/some-id`
-9. Verify redirect to `/admin/login`
-10. Navigate directly to `/superadmin/direct-streams`
-11. Verify redirect to `/admin/login` or access denied
+2. Navigate directly to `https://fieldview.live/admin/console`
+3. Verify redirect to `https://fieldview.live/admin/login`
+4. Navigate directly to `https://fieldview.live/admin/revenue`
+5. Verify redirect to `https://fieldview.live/admin/login`
+6. Navigate directly to `https://fieldview.live/admin/coupons`
+7. Verify redirect to `https://fieldview.live/admin/login`
+8. Navigate directly to `https://fieldview.live/admin/purchases/some-id`
+9. Verify redirect to `https://fieldview.live/admin/login`
+10. Navigate directly to `https://fieldview.live/superadmin/direct-streams`
+11. Verify redirect to `https://fieldview.live/admin/login` or access denied
 12. Verify no API calls succeed without a session token (check network tab for 401s)
 {/traklet:section:steps}
 
 {traklet:section:expected-result}
 ## Expected Result
-- All protected routes redirect to `/admin/login` when no session token present
+- All protected routes redirect to `https://fieldview.live/admin/login` when no session token present
 - No protected data visible during redirect (no flash of content)
 - API endpoints return 401 without valid session token
-- `/superadmin/direct-streams` is also protected
+- `https://fieldview.live/superadmin/direct-streams` is also protected
 {/traklet:section:expected-result}
 
 {traklet:section:actual-result}

--- a/.traklet/test-cases/auth-admin/TC-AA-006-support-admin-denied-superadmin.md
+++ b/.traklet/test-cases/auth-admin/TC-AA-006-support-admin-denied-superadmin.md
@@ -25,10 +25,10 @@ Verify that a user with `support_admin` role cannot access superadmin-only funct
 
 {traklet:section:steps}
 ## Steps
-1. Login as support_admin via `/admin/login`
-2. Verify successful login and redirect to `/admin/console`
+1. Login as support_admin via `https://fieldview.live/admin/login`
+2. Verify successful login and redirect to `https://fieldview.live/admin/console`
 3. Verify console search, purchase timeline, and audience pages work normally
-4. Navigate to `/superadmin/direct-streams`
+4. Navigate to `https://fieldview.live/superadmin/direct-streams`
 5. Verify access is denied (401/403 or redirect) — no stream data visible
 6. Attempt API call: `GET /api/admin/direct-streams` with support_admin session token
 7. Verify 401 response ("SuperAdmin access required")

--- a/.traklet/test-cases/auth-admin/TC-AA-007-support-admin-sees-masked-emails.md
+++ b/.traklet/test-cases/auth-admin/TC-AA-007-support-admin-sees-masked-emails.md
@@ -27,7 +27,7 @@ Verify that a support_admin sees masked viewer emails (e.g. `jo***@example.com`)
 {traklet:section:steps}
 ## Steps
 1. Login as support_admin
-2. Navigate to a game audience page (`/admin/owners/{ownerId}/games/{gameId}/audience`)
+2. Navigate to a game audience page (`https://fieldview.live/admin/owners/{ownerId}/games/{gameId}/audience`)
 3. Verify purchaser and watcher emails are masked (pattern: first 2 chars + `***` + last portion)
 4. Note the masked email format
 5. Logout

--- a/.traklet/test-cases/auth-admin/TC-AA-008-mfa-setup-enrollment.md
+++ b/.traklet/test-cases/auth-admin/TC-AA-008-mfa-setup-enrollment.md
@@ -13,7 +13,7 @@ suite: auth-admin
 
 {traklet:section:objective}
 ## Objective
-Verify the `/admin/mfa` page allows an admin to enable MFA by generating a TOTP secret, scanning a QR code, and verifying a 6-digit token.
+Verify the `https://fieldview.live/admin/mfa` page allows an admin to enable MFA by generating a TOTP secret, scanning a QR code, and verifying a 6-digit token.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -24,7 +24,7 @@ Verify the `/admin/mfa` page allows an admin to enable MFA by generating a TOTP 
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/admin/mfa`
+1. Navigate to `https://fieldview.live/admin/mfa`
 2. Verify Step 1: "Enable MFA" card with setup button
 3. Click "Set Up MFA" — verify QR code image and manual secret appear (Step 2)
 4. Scan QR code with authenticator app (or use manual secret)

--- a/.traklet/test-cases/auth-owner/TC-OA-001-owner-login-redirects-dashboard.md
+++ b/.traklet/test-cases/auth-owner/TC-OA-001-owner-login-redirects-dashboard.md
@@ -24,7 +24,7 @@ Verify an owner can sign in and land on the dashboard with an active session.
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/owners/login`
+1. Navigate to `https://fieldview.live/owners/login`
 2. Fill email (`data-testid="input-email"` if present, else labeled email field)
 3. Fill password (`data-testid="input-password"`)
 4. Submit (`data-testid="btn-submit-login"` or submit button)
@@ -33,7 +33,7 @@ Verify an owner can sign in and land on the dashboard with an active session.
 
 {traklet:section:expected-result}
 ## Expected Result
-Redirect to `/owners/dashboard` (or current canonical dashboard path). No persistent auth error. Dashboard content loads.
+Redirect to `https://fieldview.live/owners/dashboard` (or current canonical dashboard path). No persistent auth error. Dashboard content loads.
 {/traklet:section:expected-result}
 
 {traklet:section:actual-result}

--- a/.traklet/test-cases/auth-owner/TC-OA-002-owner-invalid-credentials.md
+++ b/.traklet/test-cases/auth-owner/TC-OA-002-owner-invalid-credentials.md
@@ -23,11 +23,11 @@ Ensure invalid credentials do not create a session and the user sees a clear err
 
 {traklet:section:steps}
 ## Steps
-1. Go to `/owners/login`
+1. Go to `https://fieldview.live/owners/login`
 2. Enter a real account email with an incorrect password
 3. Submit the form
 4. Observe UI feedback (`role="alert"` or `data-testid="error-*"` if present)
-5. Confirm URL is still login (or error state) and `/owners/dashboard` is not reachable without fixing credentials
+5. Confirm URL is still login (or error state) and `https://fieldview.live/owners/dashboard` is not reachable without fixing credentials
 {/traklet:section:steps}
 
 {traklet:section:expected-result}

--- a/.traklet/test-cases/auth-owner/TC-OA-003-owner-logout.md
+++ b/.traklet/test-cases/auth-owner/TC-OA-003-owner-logout.md
@@ -24,7 +24,7 @@ After logout, protected owner routes require sign-in again.
 ## Steps
 1. From dashboard, use Sign out / Logout (note `data-testid` if assigned)
 2. Confirm redirect to login or public page
-3. Manually navigate to `/owners/dashboard`
+3. Manually navigate to `https://fieldview.live/owners/dashboard`
 4. Expect redirect to login or unauthorized state
 {/traklet:section:steps}
 

--- a/.traklet/test-cases/auth-viewer/TC-VA-001-anonymous-watch-page-loads.md
+++ b/.traklet/test-cases/auth-viewer/TC-VA-001-anonymous-watch-page-loads.md
@@ -18,14 +18,14 @@ Public watch experience must not force owner login for first paint (access rules
 
 {traklet:section:prerequisites}
 ## Prerequisites
-- A valid `/watch/{org}/{team}` URL for the environment (free or paid channel per sub-test intent)
+- A valid `https://fieldview.live/watch/{org}/{team}` URL for the environment (free or paid channel per sub-test intent)
 {/traklet:section:prerequisites}
 
 {traklet:section:steps}
 ## Steps
 1. Use incognito / cleared cookies
 2. Navigate to the watch URL
-3. Confirm page loads (player shell, checkout, or paywall — not redirect to `/owners/login`)
+3. Confirm page loads (player shell, checkout, or paywall — not redirect to `https://fieldview.live/owners/login`)
 {/traklet:section:steps}
 
 {traklet:section:expected-result}

--- a/.traklet/test-cases/auth-viewer/TC-VA-002-no-pii-in-dom-for-anonymous.md
+++ b/.traklet/test-cases/auth-viewer/TC-VA-002-no-pii-in-dom-for-anonymous.md
@@ -22,7 +22,7 @@ Spot-check that anonymous watch/checkout pages do not embed emails, full names, 
 
 {traklet:section:steps}
 ## Steps
-1. As anonymous, load a public game or watch page you did not purchase
+1. As anonymous, open `https://fieldview.live/watch/[org]/[team]` (or `https://fieldview.live/game/[gameId]`) — a page you did not purchase
 2. Search page source and initial API responses for patterns like `@`, `email`, `phone`
 3. Confirm only expected marketing/support copy or your own typed form values appear
 {/traklet:section:steps}

--- a/.traklet/test-cases/auth-viewer/TC-VA-003-cross-stream-auth-persistence.md
+++ b/.traklet/test-cases/auth-viewer/TC-VA-003-cross-stream-auth-persistence.md
@@ -18,16 +18,16 @@ Verify that a viewer who registers on one direct stream is automatically authent
 
 {traklet:section:prerequisites}
 ## Prerequisites
-- Two active direct streams (e.g. `/direct/tchs` and `/direct/stormfc`)
+- Two active direct streams (e.g. `https://fieldview.live/direct/tchs` and `https://fieldview.live/direct/stormfc`)
 - Incognito browser or cleared localStorage
 {/traklet:section:prerequisites}
 
 {traklet:section:steps}
 ## Steps
-1. Open `/direct/tchs` in a clean browser
+1. Open `https://fieldview.live/direct/tchs` in a clean browser
 2. Register as a viewer (enter email + name)
 3. Verify chat unlocks and viewer identity bar appears
-4. Navigate to `/direct/stormfc`
+4. Navigate to `https://fieldview.live/direct/stormfc`
 5. Verify auto-registration occurs (no registration form shown)
 6. Verify chat is immediately unlocked on the second stream
 7. Refresh the page — verify auth persists across reload

--- a/.traklet/test-cases/chat/TC-CH-001-chat-send-receive.md
+++ b/.traklet/test-cases/chat/TC-CH-001-chat-send-receive.md
@@ -24,7 +24,7 @@ Verify that chat messages are sent and received in real-time via SSE between mul
 
 {traklet:section:steps}
 ## Steps
-1. Open the stream in two separate browser windows (Viewer A and Viewer B)
+1. Open `https://fieldview.live/direct/[slug]` in two separate browser windows (Viewer A and Viewer B)
 2. Both viewers should see the chat panel (sidebar on desktop, BottomSheet on mobile)
 3. Viewer A types a message and sends it
 4. Observe Viewer B's chat panel

--- a/.traklet/test-cases/chat/TC-CH-002-anonymous-viewer-chat.md
+++ b/.traklet/test-cases/chat/TC-CH-002-anonymous-viewer-chat.md
@@ -24,7 +24,7 @@ Verify that anonymous (non-registered) viewers automatically get a ViewerIdentit
 
 {traklet:section:steps}
 ## Steps
-1. Open the stream in an incognito window (no purchase required or free stream)
+1. Open `https://fieldview.live/direct/[slug]` in an incognito window (no purchase required or free stream)
 2. Observe the chat panel — viewer should be auto-connected
 3. Check that a viewer name is assigned
 4. Send a chat message

--- a/.traklet/test-cases/checkout/TC-CW-001-checkout-form-validation.md
+++ b/.traklet/test-cases/checkout/TC-CW-001-checkout-form-validation.md
@@ -18,7 +18,7 @@ Ensure required customer fields (e.g. email, name) block progress with accessibl
 
 {traklet:section:prerequisites}
 ## Prerequisites
-- A purchase/checkout URL for a paid game or paid watch link (`/checkout/{purchaseId}` or embedded checkout on watch page)
+- A purchase/checkout URL for a paid game or paid watch link (`https://fieldview.live/checkout/{purchaseId}` or embedded checkout on watch page)
 {/traklet:section:prerequisites}
 
 {traklet:section:steps}

--- a/.traklet/test-cases/checkout/TC-CW-003-payment-success-grants-watch.md
+++ b/.traklet/test-cases/checkout/TC-CW-003-payment-success-grants-watch.md
@@ -25,7 +25,7 @@ End-to-end: after successful Square payment (or test webhook path), viewer can w
 {traklet:section:steps}
 ## Steps
 1. Run checkout through TC-CW-002 until payment succeeds
-2. Land on success or return URL (`/checkout/.../success` pattern if used)
+2. Land on success or return URL (`https://fieldview.live/checkout/.../success` pattern if used)
 3. Navigate to watch/game page as instructed
 4. Confirm player area visible; HLS or Mux playback starts (may take a few seconds)
 {/traklet:section:steps}

--- a/.traklet/test-cases/checkout/TC-CW-004-watch-link-checkout-flow.md
+++ b/.traklet/test-cases/checkout/TC-CW-004-watch-link-checkout-flow.md
@@ -13,7 +13,7 @@ suite: checkout
 
 {traklet:section:objective}
 ## Objective
-Verify the `/watch/{org}/{team}` paid checkout flow — distinct from the game checkout — collects viewer info, shows price, and proceeds to Square payment.
+Verify the `https://fieldview.live/watch/{org}/{team}` paid checkout flow — distinct from the game checkout — collects viewer info, shows price, and proceeds to Square payment.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -24,7 +24,7 @@ Verify the `/watch/{org}/{team}` paid checkout flow — distinct from the game c
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/watch/{org}/{team}` for a paid channel
+1. Navigate to `https://fieldview.live/watch/{org}/{team}` for a paid channel
 2. Verify paywall view shows: price display, email/phone form, optional reminder checkbox
 3. Verify calendar integration buttons (Google, Outlook, iCal) if stream is scheduled
 4. Enter email and phone number

--- a/.traklet/test-cases/checkout/TC-CW-005-coupon-code-at-checkout.md
+++ b/.traklet/test-cases/checkout/TC-CW-005-coupon-code-at-checkout.md
@@ -24,7 +24,7 @@ Verify that a viewer can enter a coupon code on the game checkout page, see it v
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/game/{gameId}` for a paid game
+1. Navigate to `https://fieldview.live/game/{gameId}` for a paid game
 2. Enter email and phone
 3. Enter the coupon code in the coupon input field
 4. Click validate/apply — verify `POST /api/public/coupons/validate` is called

--- a/.traklet/test-cases/checkout/TC-CW-006-saved-payment-one-click.md
+++ b/.traklet/test-cases/checkout/TC-CW-006-saved-payment-one-click.md
@@ -25,7 +25,7 @@ Verify that a returning buyer sees their saved payment method on the payment pag
 {traklet:section:steps}
 ## Steps
 1. Create a checkout for a viewer who has a saved payment method
-2. Navigate to `/checkout/{purchaseId}/payment`
+2. Navigate to `https://fieldview.live/checkout/{purchaseId}/payment`
 3. Verify saved payment methods load (`GET /api/public/saved-payments?purchaseId=...`)
 4. Verify saved card shows last 4 digits and card brand
 5. Select the saved card

--- a/.traklet/test-cases/checkout/TC-QR-001-qr-or-deep-link-opens-checkout.md
+++ b/.traklet/test-cases/checkout/TC-QR-001-qr-or-deep-link-opens-checkout.md
@@ -17,7 +17,7 @@ Marketing QR codes or mobile deep links land on the intended game/checkout with 
 
 {traklet:section:prerequisites}
 ## Prerequisites
-- Sample QR image or raw URL from generator (`/checkout/...`, `/game/...`, or watch URL with UTM)
+- Sample QR image or raw URL from generator (`https://fieldview.live/checkout/...`, `https://fieldview.live/game/...`, or watch URL with UTM)
 {/traklet:section:prerequisites}
 
 {traklet:section:steps}

--- a/.traklet/test-cases/direct-stream/TC-DD-001-denton-diablos-stream-loads.md
+++ b/.traklet/test-cases/direct-stream/TC-DD-001-denton-diablos-stream-loads.md
@@ -13,7 +13,7 @@ suite: direct-stream
 
 {traklet:section:objective}
 ## Objective
-Confirm the Denton Diablos event page at `/direct/dentondiablos/soccer-2008-20260325` loads correctly, displays scoreboard defaults, and that the admin panel can be unlocked with the correct password.
+Confirm the Denton Diablos event page at `https://fieldview.live/direct/dentondiablos/soccer-2008-20260325` loads correctly, displays scoreboard defaults, and that the admin panel can be unlocked with the correct password.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}

--- a/.traklet/test-cases/direct-stream/TC-DS-001-nested-direct-url-loads.md
+++ b/.traklet/test-cases/direct-stream/TC-DS-001-nested-direct-url-loads.md
@@ -12,7 +12,7 @@ suite: direct-stream
 
 {traklet:section:objective}
 ## Objective
-Paths like `/direct/{slug}/...` with additional segments (e.g. multi-game schedule) resolve, fetch bootstrap JSON, and render layout — complements **TC-SP-001** which focuses on player start.
+Paths like `https://fieldview.live/direct/{slug}/...` with additional segments (e.g. multi-game schedule) resolve, fetch bootstrap JSON, and render layout — complements **TC-SP-001** which focuses on player start.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -23,7 +23,7 @@ Paths like `/direct/{slug}/...` with additional segments (e.g. multi-game schedu
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to full nested path
+1. Navigate to `https://fieldview.live/direct/[slug]/[event-slug]` (full nested URL)
 2. Wait for layout (admin FAB, scoreboard shell, player region)
 3. In Network, confirm direct-stream bootstrap/API calls return 200
 4. Regression: open admin panel per **TC-AD-001**

--- a/.traklet/test-cases/direct-stream/TC-DS-002-notify-me-subscription.md
+++ b/.traklet/test-cases/direct-stream/TC-DS-002-notify-me-subscription.md
@@ -23,7 +23,7 @@ Verify the NotifyMe feature allows viewers to subscribe to reminders for schedul
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to a direct stream page that shows "Stream Starting Soon" or offline state
+1. Navigate to `https://fieldview.live/direct/[slug]` (a stream that shows "Stream Starting Soon" or offline state)
 2. Verify "Notify Me" button or form appears
 3. Enter email (and optional name) in the NotifyMe form
 4. Submit — verify `POST /api/public/direct/{slug}/notify-me` called
@@ -31,8 +31,8 @@ Verify the NotifyMe feature allows viewers to subscribe to reminders for schedul
 6. Refresh the page — verify subscription status is detected (`GET /api/public/direct/{slug}/notify-me/status`)
 7. Unsubscribe — verify `DELETE /api/public/direct/{slug}/notify-me` called
 8. Verify unsubscribed state (NotifyMe form reappears)
-9. On `/account` page, verify the subscription appears in the subscriptions list
-10. Unsubscribe from `/account` — verify removal
+9. On `https://fieldview.live/account` page, verify the subscription appears in the subscriptions list
+10. Unsubscribe from `https://fieldview.live/account` — verify removal
 {/traklet:section:steps}
 
 {traklet:section:expected-result}
@@ -41,7 +41,7 @@ Verify the NotifyMe feature allows viewers to subscribe to reminders for schedul
 - Subscribe creates a notification subscription for the viewer
 - Status endpoint correctly reports subscribed/unsubscribed state
 - Unsubscribe removes the subscription
-- Subscription visible and manageable from `/account` page
+- Subscription visible and manageable from `https://fieldview.live/account` page
 {/traklet:section:expected-result}
 
 {traklet:section:actual-result}

--- a/.traklet/test-cases/dvr/TC-DVR-001-create-bookmark.md
+++ b/.traklet/test-cases/dvr/TC-DVR-001-create-bookmark.md
@@ -24,7 +24,7 @@ Verify that a viewer can create a bookmark at the current playback position and 
 
 {traklet:section:steps}
 ## Steps
-1. Start watching a stream and let playback advance past 30 seconds
+1. Open `https://fieldview.live/direct/[slug]` and let playback advance past 30 seconds
 2. Press the "B" keyboard shortcut or click the bookmark button
 3. Observe the timeline for a new marker
 4. Open the bookmark panel

--- a/.traklet/test-cases/dvr/TC-DVR-002-shared-bookmarks-visible.md
+++ b/.traklet/test-cases/dvr/TC-DVR-002-shared-bookmarks-visible.md
@@ -18,7 +18,7 @@ Verify that bookmarks shared by one viewer appear as blue markers on another vie
 
 {traklet:section:prerequisites}
 ## Prerequisites
-- Two authenticated viewers on the same stream
+- Two authenticated viewers on the same stream (e.g. `https://fieldview.live/direct/[slug]`)
 - DVR/bookmark feature enabled
 - Viewer A has created and shared a bookmark
 {/traklet:section:prerequisites}

--- a/.traklet/test-cases/edge-cases/TC-EX-001-expired-or-ended-access.md
+++ b/.traklet/test-cases/edge-cases/TC-EX-001-expired-or-ended-access.md
@@ -22,7 +22,7 @@ After game end time or access TTL, viewer sees explicit messaging instead of bro
 
 {traklet:section:steps}
 ## Steps
-1. Open viewer URL that previously worked
+1. Open `https://fieldview.live/direct/[slug]` (or `https://fieldview.live/game/[gameId]`) that previously worked
 2. Observe copy for ended game / expired access / code expired scenarios
 3. Confirm no infinite spinner on video element
 {/traklet:section:steps}

--- a/.traklet/test-cases/edge-cases/TC-SO-001-stream-offline-ux.md
+++ b/.traklet/test-cases/edge-cases/TC-SO-001-stream-offline-ux.md
@@ -22,7 +22,7 @@ When no live Mux/Vidstack source is available, the page communicates “starting
 
 {traklet:section:steps}
 ## Steps
-1. Open viewer page for idle fixture
+1. Open `https://fieldview.live/direct/[slug]` for an offline/idle stream fixture
 2. Read hero/player area messaging
 3. Optionally start stream upstream and verify auto-recovery (**TC-SP-001** when live)
 {/traklet:section:steps}

--- a/.traklet/test-cases/game-page/TC-GM-001-public-game-page-loads.md
+++ b/.traklet/test-cases/game-page/TC-GM-001-public-game-page-loads.md
@@ -12,7 +12,7 @@ suite: game-page
 
 {traklet:section:objective}
 ## Objective
-`/game/{gameId}` (public route) resolves for an active or scheduled game and shows the correct purchase/watch entry state.
+`https://fieldview.live/game/{gameId}` (public route) resolves for an active or scheduled game and shows the correct purchase/watch entry state.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -22,7 +22,7 @@ suite: game-page
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/game/{gameId}`
+1. Navigate to `https://fieldview.live/game/{gameId}`
 2. Confirm hero/metadata matches expected matchup
 3. Verify paywall vs free vs post-purchase UI per game config
 4. Check Network for failed bootstrap calls

--- a/.traklet/test-cases/owner-portal/TC-OW-001-dashboard-loads-revenue-snapshot.md
+++ b/.traklet/test-cases/owner-portal/TC-OW-001-dashboard-loads-revenue-snapshot.md
@@ -22,9 +22,9 @@ After owner login, dashboard summarizes games and financial snapshot without bla
 
 {traklet:section:steps}
 ## Steps
-1. Open `/owners/dashboard`
+1. Open `https://fieldview.live/owners/dashboard`
 2. Verify games list or empty state renders
-3. Open revenue section if separate; check Network for failed `/api` calls
+3. Open revenue section if separate; check Network for failed `https://fieldview.live/api` calls
 {/traklet:section:steps}
 
 {traklet:section:expected-result}

--- a/.traklet/test-cases/owner-portal/TC-OW-002-create-game-happy-path.md
+++ b/.traklet/test-cases/owner-portal/TC-OW-002-create-game-happy-path.md
@@ -23,7 +23,7 @@ Validate game creation flow from owner UI through success confirmation (keyword/
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to new game flow (`/owners/games/new` or current path)
+1. Navigate to new game flow (`https://fieldview.live/owners/games/new` or current path)
 2. Fill required fields per form labels / `data-testid`
 3. Submit and capture generated keyword or public URL snippet
 4. Open public viewer link in incognito to sanity-check (optional)

--- a/.traklet/test-cases/owner-portal/TC-OW-003-watch-links-configuration.md
+++ b/.traklet/test-cases/owner-portal/TC-OW-003-watch-links-configuration.md
@@ -12,7 +12,7 @@ suite: owner-portal
 
 {traklet:section:objective}
 ## Objective
-Ensure owners can create/update organization or channel settings that power `/watch/{org}/{team}` (access mode, price, playback binding).
+Ensure owners can create/update organization or channel settings that power `https://fieldview.live/watch/{org}/{team}` (access mode, price, playback binding).
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -25,7 +25,7 @@ Ensure owners can create/update organization or channel settings that power `/wa
 ## Steps
 1. Open watch-link or channel configuration in owner portal
 2. Set or verify `accessMode` (public free vs pay-per-view) and price if paid
-3. Save and copy shareable `/watch/...` URL
+3. Save and copy shareable `https://fieldview.live/watch/...` URL
 4. Validate with TC-WF-001 or TC-WP-001 in fresh session
 {/traklet:section:steps}
 

--- a/.traklet/test-cases/owner-portal/TC-OW-004-owner-self-registration.md
+++ b/.traklet/test-cases/owner-portal/TC-OW-004-owner-self-registration.md
@@ -12,7 +12,7 @@ suite: owner-portal
 
 {traklet:section:objective}
 ## Objective
-`/owners/register` completes account creation (or applies invite token) and user can sign in afterward.
+`https://fieldview.live/owners/register` completes account creation (or applies invite token) and user can sign in afterward.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -23,7 +23,7 @@ suite: owner-portal
 
 {traklet:section:steps}
 ## Steps
-1. Open registration form
+1. Navigate to `https://fieldview.live/owners/register` and fill the registration form
 2. Fill required fields; submit
 3. Complete email verification if required
 4. Log in via **TC-OA-001** path with new credentials

--- a/.traklet/test-cases/owner-portal/TC-OW-005-coach-console-loads.md
+++ b/.traklet/test-cases/owner-portal/TC-OW-005-coach-console-loads.md
@@ -12,7 +12,7 @@ suite: owner-portal
 
 {traklet:section:objective}
 ## Objective
-`/owners/coach` (or linked coach experience) opens for accounts with coach features—watch links, sideline tools, or audience widgets as deployed.
+`https://fieldview.live/owners/coach` (or linked coach experience) opens for accounts with coach features—watch links, sideline tools, or audience widgets as deployed.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -22,7 +22,7 @@ suite: owner-portal
 
 {traklet:section:steps}
 ## Steps
-1. From dashboard, navigate to Coach (or deep link)
+1. From `https://fieldview.live/owners/dashboard`, navigate to Coach (`https://fieldview.live/owners/coach`)
 2. Verify primary panels render
 3. Smoke one non-destructive action (e.g. view watch link list)
 {/traklet:section:steps}

--- a/.traklet/test-cases/owner-portal/TC-OW-006-games-list-filter.md
+++ b/.traklet/test-cases/owner-portal/TC-OW-006-games-list-filter.md
@@ -13,7 +13,7 @@ suite: owner-portal
 
 {traklet:section:objective}
 ## Objective
-Verify the `/owners/games` page lists the owner's games in a table with status filter and pagination.
+Verify the `https://fieldview.live/owners/games` page lists the owner's games in a table with status filter and pagination.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -24,14 +24,14 @@ Verify the `/owners/games` page lists the owner's games in a table with status f
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/owners/games`
+1. Navigate to `https://fieldview.live/owners/games`
 2. Verify table loads with columns: title, teams, date, state badge, price
 3. Verify state badges show correct colors (draft=gray, active=blue, live=green, ended=muted, cancelled=red)
 4. Use the status filter dropdown — select "active", verify table filters
 5. Switch to "draft", then "all" — verify each re-fetches correctly
 6. Verify total count label updates with each filter
 7. If 20+ games: verify pagination (Previous/Next buttons, page number)
-8. Verify "+ Create New Game" button links to `/owners/games/new`
+8. Verify "+ Create New Game" button links to `https://fieldview.live/owners/games/new`
 {/traklet:section:steps}
 
 {traklet:section:expected-result}
@@ -53,5 +53,5 @@ _Not yet tested._
 
 {traklet:section:notes}
 ## Notes
-Dashboard "Games" card now links here instead of `/owners/games/new`.
+Dashboard "Games" card now links here instead of `https://fieldview.live/owners/games/new`.
 {/traklet:section:notes}

--- a/.traklet/test-cases/owner-portal/TC-OW-007-watch-links-list.md
+++ b/.traklet/test-cases/owner-portal/TC-OW-007-watch-links-list.md
@@ -13,7 +13,7 @@ suite: owner-portal
 
 {traklet:section:objective}
 ## Objective
-Verify the `/owners/watch-links` page lists the owner's organizations with their nested channels, showing stream type, access mode, and clickable watch link previews.
+Verify the `https://fieldview.live/owners/watch-links` page lists the owner's organizations with their nested channels, showing stream type, access mode, and clickable watch link previews.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -24,12 +24,12 @@ Verify the `/owners/watch-links` page lists the owner's organizations with their
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/owners/watch-links`
+1. Navigate to `https://fieldview.live/owners/watch-links`
 2. Verify org cards load from `GET /api/owners/me/watch-links/orgs`
 3. Each org card shows name and shortName
 4. Each channel row shows: teamSlug, displayName, stream type, access mode (Free / $X.XX)
-5. Verify watch link preview `/watch/{org}/{team}` is a clickable link (opens in new tab)
-6. Verify "+ Create New Watch Link" button links to `/owners/watch-links/new`
+5. Verify watch link preview `https://fieldview.live/watch/{org}/{team}` is a clickable link (opens in new tab)
+6. Verify "+ Create New Watch Link" button links to `https://fieldview.live/owners/watch-links/new`
 7. If no orgs: verify empty state message
 {/traklet:section:steps}
 
@@ -52,5 +52,5 @@ _Not yet tested._
 
 {traklet:section:notes}
 ## Notes
-Dashboard "Watch Links" card now links here instead of `/owners/watch-links/new`.
+Dashboard "Watch Links" card now links here instead of `https://fieldview.live/owners/watch-links/new`.
 {/traklet:section:notes}

--- a/.traklet/test-cases/owner-portal/TC-OW-008-square-connect-onboarding.md
+++ b/.traklet/test-cases/owner-portal/TC-OW-008-square-connect-onboarding.md
@@ -13,7 +13,7 @@ suite: owner-portal
 
 {traklet:section:objective}
 ## Objective
-Verify the `/owners/square` page shows Square connection status, allows connecting via OAuth, and handles the post-callback success state.
+Verify the `https://fieldview.live/owners/square` page shows Square connection status, allows connecting via OAuth, and handles the post-callback success state.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -24,10 +24,10 @@ Verify the `/owners/square` page shows Square connection status, allows connecti
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/owners/square`
+1. Navigate to `https://fieldview.live/owners/square`
 2. If not connected: verify "Connect Square" card with explanation and button
 3. Click "Connect Square" — verify redirect to Square OAuth page
-4. Complete Square OAuth (sandbox) — verify redirect back to `/owners/square?square_connected=true`
+4. Complete Square OAuth (sandbox) — verify redirect back to `https://fieldview.live/owners/square?square_connected=true`
 5. Verify green success banner appears
 6. Verify status card shows: merchantId, location ID status, token expiry
 7. Refresh page — verify status persists (no success banner, but connected state remains)

--- a/.traklet/test-cases/owner-portal/TC-OW-009-direct-streams-list-filter.md
+++ b/.traklet/test-cases/owner-portal/TC-OW-009-direct-streams-list-filter.md
@@ -13,7 +13,7 @@ suite: owner-portal
 
 {traklet:section:objective}
 ## Objective
-Verify the `/owners/direct-streams` page lists the owner's direct streams in a table with status filtering.
+Verify the `https://fieldview.live/owners/direct-streams` page lists the owner's direct streams in a table with status filtering.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -24,9 +24,9 @@ Verify the `/owners/direct-streams` page lists the owner's direct streams in a t
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/owners/direct-streams`
+1. Navigate to `https://fieldview.live/owners/direct-streams`
 2. Verify table loads with columns: slug, title, scheduled, status badge, features, actions
-3. Verify slug links open `/direct/{slug}` in a new tab
+3. Verify slug links open `https://fieldview.live/direct/{slug}` in a new tab
 4. Verify feature icons show correctly (chat, scoreboard, paywall with price)
 5. Use status filter — switch between Active, Archived, All
 6. Verify table re-renders with filtered results and count updates

--- a/.traklet/test-cases/owner-portal/TC-OW-010-game-inline-edit.md
+++ b/.traklet/test-cases/owner-portal/TC-OW-010-game-inline-edit.md
@@ -24,7 +24,7 @@ Verify an owner can click a game row to expand an inline edit form, modify game 
 
 {traklet:section:steps}
 ## Steps
-1. On `/owners/games`, click a game row
+1. On `https://fieldview.live/owners/games`, click a game row
 2. Verify inline edit form expands below the row
 3. Verify form pre-fills with current values (title, teams, start time, price, state)
 4. Change the title and price

--- a/.traklet/test-cases/owner-portal/TC-OW-011-game-delete-confirmation.md
+++ b/.traklet/test-cases/owner-portal/TC-OW-011-game-delete-confirmation.md
@@ -25,7 +25,7 @@ Verify an owner can delete a game via the Delete button, with a confirmation mod
 
 {traklet:section:steps}
 ## Steps
-1. On `/owners/games`, click "Delete" button on a game row
+1. On `https://fieldview.live/owners/games`, click "Delete" button on a game row
 2. Verify confirmation modal appears with warning text ("cannot be undone")
 3. Click "Cancel" — verify modal closes, game still in table
 4. Click "Delete" again, then confirm in modal

--- a/.traklet/test-cases/owner-portal/TC-OW-012-watch-link-channel-edit.md
+++ b/.traklet/test-cases/owner-portal/TC-OW-012-watch-link-channel-edit.md
@@ -24,7 +24,7 @@ Verify an owner can expand a channel row to edit its stream URL and access mode 
 
 {traklet:section:steps}
 ## Steps
-1. On `/owners/watch-links`, click a channel row
+1. On `https://fieldview.live/owners/watch-links`, click a channel row
 2. Verify inline edit form expands with stream URL input and access mode dropdown
 3. Paste a Mux URL (`stream.mux.com/xxx`) — verify auto-detection note
 4. Change access mode from "Free" to "Pay Per View" — verify price input appears

--- a/.traklet/test-cases/owner-portal/TC-OW-013-direct-stream-create.md
+++ b/.traklet/test-cases/owner-portal/TC-OW-013-direct-stream-create.md
@@ -24,7 +24,7 @@ Verify an owner can create a new direct stream using the inline create form on t
 
 {traklet:section:steps}
 ## Steps
-1. On `/owners/direct-streams`, click "+ Create Direct Stream"
+1. On `https://fieldview.live/owners/direct-streams`, click "+ Create Direct Stream"
 2. Verify inline create form appears with fields: slug, title, admin password, stream URL
 3. Fill in slug (lowercase, hyphens only), title, admin password (8+ chars)
 4. Optionally add a stream URL

--- a/.traklet/test-cases/owner-portal/TC-OW-014-direct-stream-edit.md
+++ b/.traklet/test-cases/owner-portal/TC-OW-014-direct-stream-edit.md
@@ -24,7 +24,7 @@ Verify an owner can expand a stream row to edit its title, stream URL, scheduled
 
 {traklet:section:steps}
 ## Steps
-1. On `/owners/direct-streams`, click a stream row
+1. On `https://fieldview.live/owners/direct-streams`, click a stream row
 2. Verify inline edit form expands with pre-filled values
 3. Change the title
 4. Toggle chat, scoreboard, paywall, and listed checkboxes

--- a/.traklet/test-cases/owner-portal/TC-OW-015-direct-stream-archive.md
+++ b/.traklet/test-cases/owner-portal/TC-OW-015-direct-stream-archive.md
@@ -25,7 +25,7 @@ Verify an owner can archive an active direct stream, which changes its status ba
 
 {traklet:section:steps}
 ## Steps
-1. On `/owners/direct-streams` with "Active" filter selected
+1. On `https://fieldview.live/owners/direct-streams` with "Active" filter selected
 2. Click "Archive" button on a stream row
 3. Verify `POST /api/owners/direct-streams/:id/archive` is called
 4. Verify the stream disappears from the active list (or status badge changes to yellow)

--- a/.traklet/test-cases/paywall/TC-PW-001-paywall-blocks-unpaid.md
+++ b/.traklet/test-cases/paywall/TC-PW-001-paywall-blocks-unpaid.md
@@ -25,7 +25,7 @@ Verify that the paywall modal appears and blocks stream access for viewers who h
 {traklet:section:steps}
 ## Steps
 1. Open a new incognito/private window
-2. Navigate to `/direct/<slug>` for a paywalled stream
+2. Navigate to `https://fieldview.live/direct/[slug]` for a paywalled stream
 3. Observe the PaywallModal
 4. Attempt to dismiss the modal without purchasing
 5. Verify video content is not accessible

--- a/.traklet/test-cases/scoreboard/TC-SB-001-realtime-score-updates.md
+++ b/.traklet/test-cases/scoreboard/TC-SB-001-realtime-score-updates.md
@@ -25,7 +25,7 @@ Verify that scoreboard changes made by the producer are pushed to all viewers in
 
 {traklet:section:steps}
 ## Steps
-1. Open the stream as a viewer in one window
+1. Open `https://fieldview.live/direct/[slug]` as a viewer in one window
 2. Open the admin panel in another window (unlock with owner password)
 3. Update the home team score via the admin panel
 4. Observe the viewer's scoreboard overlay

--- a/.traklet/test-cases/scoreboard/TC-SB-002-clock-controls.md
+++ b/.traklet/test-cases/scoreboard/TC-SB-002-clock-controls.md
@@ -23,7 +23,7 @@ Verify that the game clock can be started, paused, and reset from the admin pane
 
 {traklet:section:steps}
 ## Steps
-1. Open admin panel and viewer window side by side
+1. Open `https://fieldview.live/direct/[slug]` as viewer in one window and unlock the admin panel in another
 2. Click "Start Clock" in admin panel
 3. Verify clock ticks on both admin and viewer
 4. Click "Pause Clock"

--- a/.traklet/test-cases/scoreboard/TC-SB-003-scoreboard-producer-setup.md
+++ b/.traklet/test-cases/scoreboard/TC-SB-003-scoreboard-producer-setup.md
@@ -24,7 +24,7 @@ Verify that the first-time scoreboard setup creates a scoreboard with a producer
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to a direct stream with scoreboard enabled
+1. Navigate to `https://fieldview.live/direct/[slug]` (a stream with `scoreboardEnabled: true`)
 2. Unlock admin panel (TC-AD-001)
 3. Find scoreboard setup section in admin panel
 4. Enter producer password and team names

--- a/.traklet/test-cases/smoke/TC-SM-001-home-loads.md
+++ b/.traklet/test-cases/smoke/TC-SM-001-home-loads.md
@@ -22,7 +22,7 @@ Confirm the public home page responds successfully and exposes primary entry poi
 
 {traklet:section:steps}
 ## Steps
-1. Open `/` in a fresh tab
+1. Open `https://fieldview.live/` in a fresh tab
 2. Confirm document title contains "FieldView"
 3. Verify visible CTAs: Owner Login, Get Started, View Demo Stream (or environment equivalent)
 4. Optional: open DevTools → Network, hard reload, confirm document and main JS/CSS return 200

--- a/.traklet/test-cases/stream-playback/TC-SP-001-mux-stream-loads.md
+++ b/.traklet/test-cases/stream-playback/TC-SP-001-mux-stream-loads.md
@@ -24,7 +24,7 @@ Verify that a Mux-managed direct stream loads the MuxStreamPlayer and begins pla
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/direct/<slug>` for a Mux-managed stream
+1. Navigate to `https://fieldview.live/direct/[slug]` for a Mux-managed stream
 2. Wait for the bootstrap API response
 3. Observe the video player area
 4. Verify playback begins (live indicator or progress bar advances)

--- a/.traklet/test-cases/stream-playback/TC-SP-002-vidstack-fallback.md
+++ b/.traklet/test-cases/stream-playback/TC-SP-002-vidstack-fallback.md
@@ -23,7 +23,7 @@ Verify that non-Mux streams (BYO HLS) fall back to VidstackPlayer and play corre
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/direct/<slug>` for a BYO HLS stream
+1. Navigate to `https://fieldview.live/direct/[slug]` for a BYO HLS stream
 2. Wait for bootstrap API to return `streamProvider` != `mux_managed`
 3. Observe the video player
 4. Test play/pause, seek, and fullscreen controls

--- a/.traklet/test-cases/stream-playback/TC-SP-003-responsive-layout.md
+++ b/.traklet/test-cases/stream-playback/TC-SP-003-responsive-layout.md
@@ -24,7 +24,7 @@ Verify that the stream page layout correctly adapts between mobile, tablet, and 
 
 {traklet:section:steps}
 ## Steps
-1. Open a direct stream page at desktop width (>1024px)
+1. Open `https://fieldview.live/direct/[slug]` at desktop width (>1024px)
 2. Verify chat is in sidebar, scoreboard is in sidebar
 3. Resize to tablet width (640-1024px)
 4. Verify sidebars use responsive widths `min(360px, 45vw)`

--- a/.traklet/test-cases/superadmin/TC-SU-001-direct-streams-list.md
+++ b/.traklet/test-cases/superadmin/TC-SU-001-direct-streams-list.md
@@ -12,7 +12,7 @@ suite: superadmin
 
 {traklet:section:objective}
 ## Objective
-Users with superadmin role can open direct stream management (`/superadmin/direct-streams` or current) and list/search without error.
+Users with superadmin role can open direct stream management (`https://fieldview.live/superadmin/direct-streams` or current) and list/search without error.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -23,7 +23,7 @@ Users with superadmin role can open direct stream management (`/superadmin/direc
 {traklet:section:steps}
 ## Steps
 1. Authenticate as superadmin
-2. Open direct streams admin view
+2. Navigate to `https://fieldview.live/superadmin/direct-streams`
 3. Scroll / search if UI supports it
 4. Open one row detail or edit if available (non-destructive)
 {/traklet:section:steps}

--- a/.traklet/test-cases/superadmin/TC-SU-002-create-direct-stream.md
+++ b/.traklet/test-cases/superadmin/TC-SU-002-create-direct-stream.md
@@ -13,7 +13,7 @@ suite: superadmin
 
 {traklet:section:objective}
 ## Objective
-Verify a superadmin can create a new DirectStream using the drawer form on `/superadmin/direct-streams`, with all fields validated and the new stream appearing in the table on success.
+Verify a superadmin can create a new DirectStream using the drawer form on `https://fieldview.live/superadmin/direct-streams`, with all fields validated and the new stream appearing in the table on success.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -24,7 +24,7 @@ Verify a superadmin can create a new DirectStream using the drawer form on `/sup
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/superadmin/direct-streams`
+1. Navigate to `https://fieldview.live/superadmin/direct-streams`
 2. Click "+ Create Stream" button (`btn-create-stream`)
 3. Verify drawer modal appears (`drawer-create-stream`)
 4. Fill in required fields:

--- a/.traklet/test-cases/superadmin/TC-SU-003-filter-streams-by-status.md
+++ b/.traklet/test-cases/superadmin/TC-SU-003-filter-streams-by-status.md
@@ -24,7 +24,7 @@ Verify the status dropdown filter on the direct streams console correctly filter
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/superadmin/direct-streams`
+1. Navigate to `https://fieldview.live/superadmin/direct-streams`
 2. Confirm default filter is "Active" (`select-status-filter`)
 3. Verify table shows only active streams (count label matches rows)
 4. Change filter to "Archived"

--- a/.traklet/test-cases/superadmin/TC-SU-004-impersonate-stream-admin.md
+++ b/.traklet/test-cases/superadmin/TC-SU-004-impersonate-stream-admin.md
@@ -25,12 +25,12 @@ Verify a superadmin can impersonate a stream's admin by clicking the Impersonate
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/superadmin/direct-streams`
+1. Navigate to `https://fieldview.live/superadmin/direct-streams`
 2. Locate an active stream row
 3. Click "Impersonate Admin" button (`btn-impersonate-{slug}`)
 4. Verify API call: `POST /api/admin/direct-streams/{slug}/impersonate` returns 200
 5. Verify `admin_token_{slug}` is set in localStorage
-6. Verify a new tab opens to `/{slug}`
+6. Verify a new tab opens to `https://fieldview.live/direct/[slug]`
 7. In the new tab, confirm admin panel is unlocked (producer controls visible without needing to enter password)
 {/traklet:section:steps}
 

--- a/.traklet/test-cases/superadmin/TC-SU-005-view-registrations-modal.md
+++ b/.traklet/test-cases/superadmin/TC-SU-005-view-registrations-modal.md
@@ -24,7 +24,7 @@ Verify clicking the registrations count link on a stream row opens a modal showi
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/superadmin/direct-streams`
+1. Navigate to `https://fieldview.live/superadmin/direct-streams`
 2. Find a stream row with a registrations count link (`btn-registrations-{slug}`)
 3. Click the registrations count link
 4. Verify modal appears (`modal-registrations`)

--- a/.traklet/test-cases/superadmin/TC-SU-006-create-stream-validation-errors.md
+++ b/.traklet/test-cases/superadmin/TC-SU-006-create-stream-validation-errors.md
@@ -23,7 +23,7 @@ Verify the create stream drawer form surfaces inline validation errors for inval
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/superadmin/direct-streams`
+1. Navigate to `https://fieldview.live/superadmin/direct-streams`
 2. Click "+ Create Stream" (`btn-create-stream`)
 3. Leave all fields empty, click "Create Stream" (`btn-submit-create`)
 4. Verify inline errors appear for slug (`error-slug`), title (`error-title`), and admin password (`error-admin-password`)

--- a/.traklet/test-cases/superadmin/TC-SU-007-expand-row-view-subevents.md
+++ b/.traklet/test-cases/superadmin/TC-SU-007-expand-row-view-subevents.md
@@ -24,7 +24,7 @@ Verify clicking the expand toggle on a stream row loads the EventManagement comp
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/superadmin/direct-streams`
+1. Navigate to `https://fieldview.live/superadmin/direct-streams`
 2. Click the expand button on a stream row (`btn-expand-{slug}`)
 3. Verify the icon changes from "▶" to "▼"
 4. Verify EventManagement component loads below the row (`row-event-{slug}`)
@@ -54,5 +54,5 @@ _Not yet tested._
 
 {traklet:section:notes}
 ## Notes
-Event slug links should open `/direct/{parentSlug}/{eventSlug}` in a new tab.
+Event slug links should open `https://fieldview.live/direct/{parentSlug}/{eventSlug}` in a new tab.
 {/traklet:section:notes}

--- a/.traklet/test-cases/verify-access/TC-VF-001-verify-access-flow.md
+++ b/.traklet/test-cases/verify-access/TC-VF-001-verify-access-flow.md
@@ -12,7 +12,7 @@ suite: verify-access
 
 {traklet:section:objective}
 ## Objective
-`/verify-access` (or current path) correctly validates emailed or shared tokens and redirects to the watch experience without breaking purchase state.
+`https://fieldview.live/verify-access` (or current path) correctly validates emailed or shared tokens and redirects to the watch experience without breaking purchase state.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -22,7 +22,7 @@ suite: verify-access
 
 {traklet:section:steps}
 ## Steps
-1. Paste magic link or open from email on target device
+1. Paste magic link or open from email — lands on `https://fieldview.live/verify-access?token=...`
 2. Complete any on-page confirm step
 3. Confirm redirect to game/watch and player accessible
 4. Try reusing same token in new session — expect one-time failure if designed

--- a/.traklet/test-cases/watch-links/TC-EC-001-valid-event-code-grants-access.md
+++ b/.traklet/test-cases/watch-links/TC-EC-001-valid-event-code-grants-access.md
@@ -12,7 +12,7 @@ suite: watch-links
 
 {traklet:section:objective}
 ## Objective
-`/watch/{org}/{team}/{code}` (or query-param variant if your build uses it) accepts a valid event code and loads viewer experience.
+`https://fieldview.live/watch/{org}/{team}/{code}` (or query-param variant if your build uses it) accepts a valid event code and loads viewer experience.
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -22,7 +22,7 @@ suite: watch-links
 
 {traklet:section:steps}
 ## Steps
-1. Construct URL with valid `code` segment per routing in `apps/web`
+1. Construct URL: `https://fieldview.live/watch/[org]/[team]/[code]` with a valid event code
 2. Load in fresh session
 3. Confirm access (player or post-checkout state) — not “invalid code” error
 {/traklet:section:steps}

--- a/.traklet/test-cases/watch-links/TC-EC-002-invalid-event-code-denied.md
+++ b/.traklet/test-cases/watch-links/TC-EC-002-invalid-event-code-denied.md
@@ -23,7 +23,7 @@ Bad codes do not grant playback; user sees actionable error (403/404 messaging p
 
 {traklet:section:steps}
 ## Steps
-1. Open watch URL with garbage `code`
+1. Open `https://fieldview.live/watch/[org]/[team]/invalid-code` with a garbage/expired code
 2. Observe HTTP status (if full page) or inline error component
 3. Retry with known-expired code if available
 {/traklet:section:steps}

--- a/.traklet/test-cases/watch-links/TC-WF-001-public-free-watch-link.md
+++ b/.traklet/test-cases/watch-links/TC-WF-001-public-free-watch-link.md
@@ -12,7 +12,7 @@ suite: watch-links
 
 {traklet:section:objective}
 ## Objective
-For `accessMode: public_free`, `/watch/{org}/{team}` should render the viewing experience directly (no purchase form).
+For `accessMode: public_free`, `https://fieldview.live/watch/{org}/{team}` should render the viewing experience directly (no purchase form).
 {/traklet:section:objective}
 
 {traklet:section:prerequisites}
@@ -23,7 +23,7 @@ For `accessMode: public_free`, `/watch/{org}/{team}` should render the viewing e
 
 {traklet:section:steps}
 ## Steps
-1. Navigate to `/watch/{org}/{team}` for the free channel
+1. Navigate to `https://fieldview.live/watch/{org}/{team}` for the free channel
 2. Confirm checkout/pay form for this channel is absent (unless cross-sell is intentional — document)
 3. Confirm player shell or stream-offline message appears
 {/traklet:section:steps}

--- a/.traklet/test-cases/watch-links/TC-WP-001-pay-per-view-watch-link.md
+++ b/.traklet/test-cases/watch-links/TC-WP-001-pay-per-view-watch-link.md
@@ -23,7 +23,7 @@ Paid watch channel surfaces price and purchase path before revealing the player 
 
 {traklet:section:steps}
 ## Steps
-1. Open `/watch/{org}/{team}` incognito
+1. Open `https://fieldview.live/watch/{org}/{team}` incognito
 2. Verify checkout or paywall UI visible with correct price display
 3. Confirm video is not fully accessible until purchase path completes (align with **TC-PW-001** for direct streams)
 {/traklet:section:steps}

--- a/apps/web/test-results/.last-run.json
+++ b/apps/web/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
Housekeeping split out of the doc-cleanup effort.

- **.gitignore**: ignore `test-results/`, `playwright-report/`, `*.code-workspace` (`veo-poc-output/` already ignored — holds a Mux stream key)
- Stop tracking the generated `apps/web/test-results/.last-run.json`
- Update `.traklet/` test-case tracker data (+ `config.md`, `settings.template.json`)
- Delete a stray duplicate Apple domain-association file

No application code or dependencies touched. WIP features land separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)