### PR TITLE
docs: Model A → relay Connect Hub (Slice 1 shipped 2026-07-19)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -17,7 +17,7 @@ Default: `ROLE: engineer STRICT=true` (read-only unless approved)
 
 ## 💳 PAYMENT & COMMS ARCHITECTURE — DECIDED DIRECTION
 
-> **Status: DECIDED, but BUILD IS PAUSED.** Do NOT implement the payment workflow yet, and do NOT extend the legacy in-repo Square integration. Owner is updating the relay first.
+> **Status: DECIDED. Relay Connect Hub shipped (2026-07-19).** Migrate FieldView off the in-repo Square "Model A" to the relay Connect Hub — see `docs/RELAY-CONNECT-HUB-MIGRATION.md`. Do NOT extend Model A. Go-live gated on attorney ToS/Recipient-Agreement review + first real coach.
 
 **Backbone = Noctusoft Relay** (`docs.api.noctusoft.com`). ALL Square, Twilio, SendGrid, and Google traffic routes through the relay via drop-in base-URL swap. The relay injects vendor credentials server-side — **this repo must hold NO Square / Twilio / SendGrid / Google secrets.**
 
@@ -28,15 +28,14 @@ Default: `ROLE: engineer STRICT=true` (read-only unless approved)
 | SendGrid / email | `api.sendgrid.noctusoft.com` |
 | Auth to relay | Railway deploy key via env `NOCTUSOFT_API_KEY` (any IP) |
 
-**Payment model = single-account via the relay, with relay-side variable platform-fee retention.**
-- Viewer payments settle into the platform Square account **through the relay**.
-- The **relay retains a configurable platform fee (default 10%; settable to 5% or a variable %)** and attributes the remainder to the coach/owner.
-- FieldView records per-coach earnings; coach payout follows the relay/settlement model.
-- **Supersedes** the current in-repo Square Marketplace "Model A" (per-coach OAuth + `applicationFeeMoney`). Do NOT build on Model A; migrate toward the relay.
+**Payment model = marketplace via the relay's Square Connect Hub** (`api.square.noctusoft.com/connect/fieldview/*`). _Updated 2026-07-19 — replaces the earlier 'single-account' wording._
+- Each coach OAuth-connects their **own** Square merchant via the relay (`/connect/fieldview/oauth/authorize?recipient_key=...`). Relay stores the coach's tokens — **FieldView stores only a `recipientKey`, never Square tokens.**
+- Viewer payment = `POST /connect/fieldview/recipients/:key/charge` with `app_fee_money`: **~90% → coach's own Square, ~10% → platform** (rate = `app_fee_bps`, configurable per product/transaction; default 1000 bps = 10%).
+- **FieldView never holds coach funds** — Square splits at charge time (no money-transmitter exposure).
+- Refunds: `/connect/fieldview/recipients/:key/refunds` (app fee reversed proportionally). Card-on-file + subscriptions supported. Square webhooks via relay `/connect/webhooks/:env` fanout.
+- **Supersedes/replaces** the in-repo Square "Model A" (in-repo per-coach token storage + direct `applicationFeeMoney`). Delete the in-repo Square token/OAuth machinery. See `docs/RELAY-CONNECT-HUB-MIGRATION.md`.
 
-**⏸️ Blocking:** Owner is adding the variable platform-fee-retention pattern to the relay. Wait for it before implementing payments.
-
-**🔒 Security TODO (before go-live):** relay docs page serves live keys over a plain fetch — rotate keys + gate the page.
+**🔒 Security:** relay docs keys now redacted (2026-07-19); rotate if previously-exposed values weren't already rotated.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,15 +17,16 @@
 | SendGrid / email | `api.sendgrid.noctusoft.com` |
 | Auth to relay | Railway **deploy key** via env `NOCTUSOFT_API_KEY` (works from any IP) |
 
-**Payment model = single-account via the relay, with relay-side variable platform-fee retention.**
-- Viewer payments settle into the platform Square account **through the relay**.
-- The **relay retains a configurable platform fee — default 10%, settable to 5% or a variable % —** and attributes the remainder to the coach/owner.
-- FieldView records per-coach earnings; coach payout follows the relay/settlement model.
-- This **supersedes** the current in-repo Square Marketplace "Model A" (per-coach OAuth + `applicationFeeMoney`). **Do not build on Model A; migrate toward the relay.**
+**Payment model = marketplace via the relay's Square Connect Hub** (`api.square.noctusoft.com/connect/fieldview/*`). _Updated 2026-07-19 — replaces the earlier "single-account" wording._
+- Each coach OAuth-connects their **own** Square merchant through the relay (`GET /connect/fieldview/oauth/authorize?recipient_key=...`). The relay stores the coach's Square tokens — **FieldView stores only a `recipientKey`, never Square tokens.**
+- Viewer payment = `POST /connect/fieldview/recipients/:key/charge` with `app_fee_money`: **~90% → the coach's own Square balance, ~10% → the platform** (rate = `app_fee_bps`, configurable per product & per transaction; default 10% = 1000 bps).
+- **FieldView never holds coach funds** — Square splits at charge time (no money-transmitter/escrow exposure).
+- Refunds: `POST /connect/fieldview/recipients/:key/refunds` (app fee reversed proportionally). Card-on-file + subscription lifecycle supported. Square webhooks arrive via the relay's `POST /connect/webhooks/:env` fanout to FieldView's callback URL.
+- This **supersedes and replaces** the in-repo Square "Model A" (in-repo per-coach OAuth token storage + direct `applicationFeeMoney`). Migrate FieldView to call the Connect Hub; delete the in-repo Square token/OAuth machinery. See `docs/RELAY-CONNECT-HUB-MIGRATION.md`.
 
-**⏸️ Blocking:** Owner is updating the relay to add the variable platform-fee-retention pattern. **Wait for that to land before implementing the payment workflow.**
+**Status (2026-07-19):** relay Connect Hub "Slice 1" is backend-complete (101 tests, production canary-proven: $1 charge + 10¢ fee + refund). Gated on: attorney ToS/Recipient-Agreement review, the FieldView-side integration/UI, and the first real coach.
 
-**🔒 Security TODO (before go-live):** the relay docs page currently serves live keys over a plain fetch — rotate the relay keys and properly gate the page. (Owner asked for help locking this down.)
+**🔒 Security:** relay docs keys are now redacted (2026-07-19). If the previously-exposed values were not rotated, rotate them.
 
 ---
 


### PR DESCRIPTION
## Summary

Update FieldView's authoritative rule files (`.cursorrules`, `CLAUDE.md`) to reflect that the relay's **Square Connect Hub Slice 1** is now backend-complete and production-canary-proven (2026-07-19: $1 charge with 10¢ app_fee_money, refunded, on the `fieldview` product_key).

- Remove the "BUILD IS PAUSED / wait for relay" gating text.
- Replace old "single-account with platform-fee retention" wording with the actual shipped shape: **per-coach OAuth** via `/connect/fieldview/*`, **Square splits at charge time** via `app_fee_money` (~90/10), FieldView stores only a `recipientKey` — never Square tokens.
- Point at `docs/RELAY-CONNECT-HUB-MIGRATION.md` for the migration path off the in-repo "Model A" (per-coach OAuth token storage + direct `applicationFeeMoney`).
- Note real go-live is still gated on attorney ToS/Recipient Agreement review + the first real coach.
- Update "Security TODO" line to reflect that relay docs keys are now redacted (rotate previously-exposed values if not already done).

Docs-only; no runtime code change.

## Test plan
- [x] `.cursorrules` and `CLAUDE.md` reviewed for accuracy against Slice 1 endpoint contract
- [x] References in-repo docs paths (`docs/RELAY-CONNECT-HUB-MIGRATION.md`) exist / are being added separately
- [x] No secret values introduced

Related:
- Relay repo: `github.com/rvegajr/noctusoft-relay` (`connect/` module)
- Companion migration PRs already merged: BlessBox #58, EscalatingReminders #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)