### PR TITLE
fix(payments): correct relay Connect Hub client to verified live contract

### DIFF
--- a/apps/api/src/routes/owners.payments.ts
+++ b/apps/api/src/routes/owners.payments.ts
@@ -93,7 +93,7 @@ router.post(
 
         const recipientKey = owner.relayRecipientKey || owner.id;
         const version = (req.body as { version?: string }).version || AGREEMENT_VERSION;
-        const result = await getRelayService().acceptAgreement(recipientKey, version);
+        const result = await getRelayService().acceptAgreement(recipientKey, version, req.ip);
 
         await repo.update(owner.id, {
           relayRecipientKey: recipientKey,
@@ -125,9 +125,11 @@ router.get('/me/payments/status', requireOwnerAuth, (req: AuthRequest, res, next
 
       const recipientKey = owner.relayRecipientKey || null;
       let connected = false;
+      let merchantId: string | null = null;
       if (recipientKey) {
         const status = await getRelayService().getRecipientStatus(recipientKey);
         connected = status.connected;
+        merchantId = status.merchantId;
         if (connected && !owner.paymentsConnectedAt) {
           await repo.update(owner.id, { paymentsConnectedAt: new Date() });
         }
@@ -135,6 +137,7 @@ router.get('/me/payments/status', requireOwnerAuth, (req: AuthRequest, res, next
 
       res.json({
         recipientKey,
+        merchantId,
         agreementAccepted: Boolean(owner.agreementAcceptedVersion),
         agreementVersion: owner.agreementAcceptedVersion || null,
         connected,

--- a/apps/api/src/routes/public.payment-config.ts
+++ b/apps/api/src/routes/public.payment-config.ts
@@ -62,7 +62,9 @@ router.get('/purchases/:purchaseId/payment-config', (req, res, next) => {
         provider: 'relay',
         applicationId: cfg.applicationId,
         environment: cfg.environment,
-        locationId: cfg.locationId ?? null,
+        // locationId is the coach's own Square location — the relay does NOT return it;
+        // it comes from FieldView's stored OwnerAccount.squareLocationId.
+        locationId: owner.squareLocationId ?? null,
       });
     } catch (error) {
       next(error);

--- a/apps/api/src/services/IRelayConnectHubService.ts
+++ b/apps/api/src/services/IRelayConnectHubService.ts
@@ -1,69 +1,69 @@
 /**
  * Relay Connect Hub Service Interfaces (ISP).
  *
- * Segregated interfaces for onboarding a coach (recipient) onto the relay's
- * Square Connect Hub. Payment operations (charge/refund) land in a separate
- * interface in Slice 2, once response shapes are verified against the live relay.
- *
- * See docs/RELAY-CONNECT-HUB-MIGRATION.md.
+ * Shapes verified against the relay's authoritative INTEGRATION.md + captured
+ * production responses (2026-07-19 canary). See docs/RELAY-CONNECT-HUB-MIGRATION.md.
  */
 
 export interface RelayFrontendConfig {
-  /** Square Web Payments SDK application id for this recipient's seller context. */
+  /** Square Web Payments SDK application id (relay-provided). */
   applicationId: string;
   environment: 'production' | 'sandbox';
-  /** Recipient (coach) Square location id, when the relay returns it. */
-  locationId?: string;
+  // NOTE: locationId does NOT come from the relay — it belongs to the coach's own
+  // Square account and is supplied by FieldView (OwnerAccount.squareLocationId).
 }
 
 export interface RelayRecipientStatus {
-  connected: boolean;
+  connected: boolean; // true once merchant_id is present (OAuth completed)
   recipientKey: string;
-  merchantId?: string | null;
+  merchantId: string | null;
+  connectedAt: string | null;
+  agreementVersionAccepted: string | null;
+}
+
+export interface RelayAgreementResult {
+  accepted: boolean;
+  version: string;
+  acceptedAt: number | null; // unix seconds
 }
 
 /**
- * Onboarding Interface (ISP).
- *
- * Covers: starting the coach's Square OAuth via the relay, recording Recipient
- * Agreement acceptance, and reading connection/frontend config.
+ * Onboarding Interface (ISP): start Square OAuth via the relay, record Recipient
+ * Agreement acceptance, and read connection/frontend config.
  */
 export interface IRelayConnectOnboarding {
   /** Pure URL builder — the browser navigates here to begin Square OAuth via the relay. */
   buildAuthorizeUrl(recipientKey: string, postConnectRedirect?: string): string;
-  acceptAgreement(recipientKey: string, version: string): Promise<{ accepted: boolean; version: string }>;
+  acceptAgreement(recipientKey: string, version: string, ip?: string): Promise<RelayAgreementResult>;
   getFrontendConfig(recipientKey: string): Promise<RelayFrontendConfig>;
   getRecipientStatus(recipientKey: string): Promise<RelayRecipientStatus>;
 }
 
 /**
  * A one-time charge on the recipient's (coach's) Square merchant via the relay.
- * The relay applies the platform `app_fee_money` from the product's `app_fee_bps`
- * (override per-transaction with `appFeeBps`). Documented input fields: note,
- * referenceId, statementDescriptionIdentifier, buyerEmailAddress.
+ * The relay applies the platform `app_fee_money` from the product's configured
+ * `app_fee_bps`; pass `appFeeBps` only to override (subject to the product ceiling).
  */
 export interface RelayChargeInput {
-  sourceId: string; // Square Web Payments SDK nonce
+  sourceId: string; // Square Web Payments SDK nonce (cnon:...)
   amountCents: number;
-  currency?: string; // default USD
   idempotencyKey: string;
-  appFeeBps?: number; // override the product default (basis points)
+  appFeeBps?: number; // optional per-transaction override
   note?: string;
   referenceId?: string; // link to a FieldView record (use purchaseId)
   statementDescriptionIdentifier?: string;
   buyerEmailAddress?: string;
 }
 
-/**
- * Result of a relay charge/refund. Response field names are parsed defensively
- * (`raw` carries the full relay body) pending confirmation against the live relay.
- */
+/** Parsed from the relay's `{ payment: {...} }` envelope. `raw` carries the full body. */
 export interface RelayChargeResult {
   paymentId: string;
-  status: string;
+  status: string; // COMPLETED | PENDING | APPROVED | FAILED | CANCELED
   amountCents: number;
   appFeeCents: number | null;
-  processingFeeCents: number | null;
+  cardBrand: string | null;
+  cardLast4: string | null;
+  receiptUrl: string | null;
   raw: unknown;
 }
 
@@ -74,9 +74,10 @@ export interface RelayRefundInput {
   reason?: string;
 }
 
+/** Parsed from the relay's `{ refund: {...} }` envelope. */
 export interface RelayRefundResult {
   refundId: string;
-  status: string;
+  status: string; // PENDING | COMPLETED | REJECTED | FAILED
   amountCents: number;
   raw: unknown;
 }

--- a/apps/api/src/services/RelayConnectHubService.ts
+++ b/apps/api/src/services/RelayConnectHubService.ts
@@ -3,12 +3,10 @@
  *
  * Thin client over the Noctusoft Relay's Square Connect Hub
  * (`<baseUrl>/connect/<product>/*`). The relay owns each coach's Square OAuth
- * tokens; FieldView only references them by `recipientKey`.
+ * tokens; FieldView references them by `recipientKey`.
  *
- * NOTE: relay JSON response field names are handled defensively (snake_case and
- * camelCase both accepted) pending confirmation against the live relay canary.
- *
- * See docs/RELAY-CONNECT-HUB-MIGRATION.md.
+ * Request/response shapes verified against the relay's INTEGRATION.md and the
+ * captured 2026-07-19 production canary. See docs/RELAY-CONNECT-HUB-MIGRATION.md.
  */
 
 import { BadRequestError } from '../lib/errors';
@@ -17,6 +15,7 @@ import type { RelayConfig } from '../lib/relay';
 import type {
   IRelayConnectOnboarding,
   IRelayConnectPayments,
+  RelayAgreementResult,
   RelayChargeInput,
   RelayChargeResult,
   RelayFrontendConfig,
@@ -27,22 +26,8 @@ import type {
 
 type FetchFn = typeof globalThis.fetch;
 
-/** First string value found among candidate keys. */
-function pickString(obj: Record<string, unknown>, keys: string[]): string | undefined {
-  for (const k of keys) {
-    const v = obj[k];
-    if (typeof v === 'string' && v.length > 0) return v;
-  }
-  return undefined;
-}
-
-/** First finite number found among candidate keys. */
-function pickNumber(obj: Record<string, unknown>, keys: string[]): number | undefined {
-  for (const k of keys) {
-    const v = obj[k];
-    if (typeof v === 'number' && Number.isFinite(v)) return v;
-  }
-  return undefined;
+interface MoneyLike {
+  amount?: number;
 }
 
 export class RelayConnectHubService implements IRelayConnectOnboarding, IRelayConnectPayments {
@@ -66,6 +51,19 @@ export class RelayConnectHubService implements IRelayConnectOnboarding, IRelayCo
     };
   }
 
+  /** Parse the relay error envelope ({ error, code, squareErrors[] }) and throw a useful message. */
+  private async throwRelayError(res: Response, prefix: string): Promise<never> {
+    const data = (await res.json().catch(() => ({}))) as {
+      error?: string;
+      code?: string;
+      squareErrors?: Array<{ code?: string; detail?: string }>;
+    };
+    const sq = data.squareErrors?.[0];
+    const detail = sq?.detail || data.error || `HTTP ${res.status}`;
+    const code = sq?.code || data.code;
+    throw new BadRequestError(code ? `${prefix}: ${detail} [${code}]` : `${prefix}: ${detail}`);
+  }
+
   buildAuthorizeUrl(recipientKey: string, postConnectRedirect?: string): string {
     const url = new URL(`${this.base()}/oauth/authorize`);
     url.searchParams.set('recipient_key', recipientKey);
@@ -75,17 +73,24 @@ export class RelayConnectHubService implements IRelayConnectOnboarding, IRelayCo
     return url.toString();
   }
 
-  async acceptAgreement(recipientKey: string, version: string): Promise<{ accepted: boolean; version: string }> {
+  async acceptAgreement(recipientKey: string, version: string, ip?: string): Promise<RelayAgreementResult> {
     const res = await this.fetchFn(`${this.recipientBase(recipientKey)}/agreement`, {
       method: 'POST',
       headers: this.headers(),
-      body: JSON.stringify({ version }),
+      body: JSON.stringify({ agreement_version: version, ...(ip ? { ip } : {}) }),
     });
     if (!res.ok) {
-      throw new BadRequestError('Relay: failed to record agreement acceptance');
+      return this.throwRelayError(res, 'Relay agreement acceptance failed');
     }
-    const body = (await res.json().catch(() => ({}))) as { version?: string };
-    return { accepted: true, version: body.version ?? version };
+    const body = (await res.json().catch(() => ({}))) as {
+      agreement_version_accepted?: string;
+      agreement_accepted_at?: number;
+    };
+    return {
+      accepted: true,
+      version: body.agreement_version_accepted ?? version,
+      acceptedAt: typeof body.agreement_accepted_at === 'number' ? body.agreement_accepted_at : null,
+    };
   }
 
   async getFrontendConfig(recipientKey: string): Promise<RelayFrontendConfig> {
@@ -94,45 +99,51 @@ export class RelayConnectHubService implements IRelayConnectOnboarding, IRelayCo
       headers: this.headers(),
     });
     if (!res.ok) {
-      throw new BadRequestError('Relay: failed to fetch frontend config');
+      return this.throwRelayError(res, 'Relay frontend-config failed');
     }
-    const body = (await res.json()) as {
-      application_id?: string;
-      applicationId?: string;
-      environment?: string;
-      location_id?: string;
-      locationId?: string;
-    };
-    const applicationId = body.application_id ?? body.applicationId;
-    if (!applicationId) {
-      throw new BadRequestError('Relay: frontend config missing application_id');
+    const body = (await res.json()) as { application_id?: string; environment?: string };
+    if (!body.application_id) {
+      throw new BadRequestError('Relay: frontend-config missing application_id');
     }
     return {
-      applicationId,
+      applicationId: body.application_id,
       environment: body.environment === 'production' ? 'production' : 'sandbox',
-      locationId: body.location_id ?? body.locationId,
     };
   }
 
-  /**
-   * Connection status. Derived from whether the relay resolves a frontend-config
-   * for this recipient (a connected recipient has a Square seller context).
-   * TODO(slice-0): replace with a dedicated relay status endpoint if one exists.
-   */
+  /** Connection status from GET /recipients/:key — connected once merchant_id is present. */
   async getRecipientStatus(recipientKey: string): Promise<RelayRecipientStatus> {
-    try {
-      const cfg = await this.getFrontendConfig(recipientKey);
-      return { connected: Boolean(cfg.applicationId), recipientKey };
-    } catch {
-      return { connected: false, recipientKey };
+    const res = await this.fetchFn(this.recipientBase(recipientKey), {
+      method: 'GET',
+      headers: this.headers(),
+    });
+    if (!res.ok) {
+      return {
+        connected: false,
+        recipientKey,
+        merchantId: null,
+        connectedAt: null,
+        agreementVersionAccepted: null,
+      };
     }
+    const body = (await res.json().catch(() => ({}))) as {
+      merchant_id?: string | null;
+      connected_at?: string | null;
+      agreement_version_accepted?: string | null;
+    };
+    return {
+      connected: Boolean(body.merchant_id),
+      recipientKey,
+      merchantId: body.merchant_id ?? null,
+      connectedAt: body.connected_at ?? null,
+      agreementVersionAccepted: body.agreement_version_accepted ?? null,
+    };
   }
 
   async charge(recipientKey: string, input: RelayChargeInput): Promise<RelayChargeResult> {
     const body: Record<string, unknown> = {
       source_id: input.sourceId,
       amount_cents: input.amountCents,
-      currency: input.currency ?? 'USD',
       idempotency_key: input.idempotencyKey,
       ...(input.appFeeBps !== undefined && { app_fee_bps: input.appFeeBps }),
       ...(input.note && { note: input.note }),
@@ -149,16 +160,22 @@ export class RelayConnectHubService implements IRelayConnectOnboarding, IRelayCo
       body: JSON.stringify(body),
     });
     if (!res.ok) {
-      throw new BadRequestError('Relay: charge failed');
+      return this.throwRelayError(res, 'Relay charge failed');
     }
 
-    const data = (await res.json()) as Record<string, unknown>;
+    const data = (await res.json()) as { payment?: Record<string, unknown> };
+    const p = (data.payment ?? {}) as Record<string, unknown>;
+    const amountMoney = p.amount_money as MoneyLike | undefined;
+    const appFeeMoney = p.app_fee_money as MoneyLike | undefined;
+    const card = (p.card_details as { card?: { card_brand?: string; last_4?: string } } | undefined)?.card;
     return {
-      paymentId: pickString(data, ['payment_id', 'paymentId', 'id']) ?? '',
-      status: pickString(data, ['status']) ?? 'unknown',
-      amountCents: pickNumber(data, ['amount_cents', 'amountCents']) ?? input.amountCents,
-      appFeeCents: pickNumber(data, ['app_fee_cents', 'appFeeCents', 'app_fee_money']) ?? null,
-      processingFeeCents: pickNumber(data, ['processing_fee_cents', 'processingFeeCents']) ?? null,
+      paymentId: typeof p.id === 'string' ? p.id : '',
+      status: typeof p.status === 'string' ? p.status : 'unknown',
+      amountCents: typeof amountMoney?.amount === 'number' ? amountMoney.amount : input.amountCents,
+      appFeeCents: typeof appFeeMoney?.amount === 'number' ? appFeeMoney.amount : null,
+      cardBrand: card?.card_brand ?? null,
+      cardLast4: card?.last_4 ?? null,
+      receiptUrl: typeof p.receipt_url === 'string' ? p.receipt_url : null,
       raw: data,
     };
   }
@@ -177,14 +194,16 @@ export class RelayConnectHubService implements IRelayConnectOnboarding, IRelayCo
       body: JSON.stringify(body),
     });
     if (!res.ok) {
-      throw new BadRequestError('Relay: refund failed');
+      return this.throwRelayError(res, 'Relay refund failed');
     }
 
-    const data = (await res.json()) as Record<string, unknown>;
+    const data = (await res.json()) as { refund?: Record<string, unknown> };
+    const r = (data.refund ?? {}) as Record<string, unknown>;
+    const amountMoney = r.amount_money as MoneyLike | undefined;
     return {
-      refundId: pickString(data, ['refund_id', 'refundId', 'id']) ?? '',
-      status: pickString(data, ['status']) ?? 'unknown',
-      amountCents: pickNumber(data, ['amount_cents', 'amountCents']) ?? input.amountCents,
+      refundId: typeof r.id === 'string' ? r.id : '',
+      status: typeof r.status === 'string' ? r.status : 'unknown',
+      amountCents: typeof amountMoney?.amount === 'number' ? amountMoney.amount : input.amountCents,
       raw: data,
     };
   }

--- a/apps/api/src/services/__tests__/RelayConnectHubService.test.ts
+++ b/apps/api/src/services/__tests__/RelayConnectHubService.test.ts
@@ -1,8 +1,8 @@
 /**
  * RelayConnectHubService tests.
  *
- * The relay is mocked via an injected fetch function — no network. Verifies
- * request construction (URL/method/headers/body) and response parsing.
+ * The relay is mocked via an injected fetch function — no network. Request/response
+ * shapes mirror the relay's INTEGRATION.md + captured production canary (2026-07-19).
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -16,11 +16,8 @@ const config: RelayConfig = {
   apiKey: 'nsins_dk_test',
 };
 
-function jsonResponse(body: unknown, ok = true): Response {
-  return {
-    ok,
-    json: () => Promise.resolve(body),
-  } as unknown as Response;
+function jsonResponse(body: unknown, ok = true, status = ok ? 200 : 400): Response {
+  return { ok, status, json: () => Promise.resolve(body) } as unknown as Response;
 }
 
 describe('RelayConnectHubService', () => {
@@ -33,58 +30,47 @@ describe('RelayConnectHubService', () => {
   });
 
   describe('buildAuthorizeUrl', () => {
-    it('builds the Connect Hub authorize URL with recipient_key', () => {
-      const url = svc.buildAuthorizeUrl('owner-123');
-      expect(url).toBe('https://relay.test/connect/fieldview/oauth/authorize?recipient_key=owner-123');
-    });
-
-    it('includes the post-connect redirect when provided', () => {
+    it('builds the Connect Hub authorize URL with recipient_key (no network)', () => {
       const url = svc.buildAuthorizeUrl('owner-123', 'https://app.fieldview.live/owners/dashboard');
       const parsed = new URL(url);
+      expect(`${parsed.origin}${parsed.pathname}`).toBe('https://relay.test/connect/fieldview/oauth/authorize');
       expect(parsed.searchParams.get('recipient_key')).toBe('owner-123');
       expect(parsed.searchParams.get('redirect')).toBe('https://app.fieldview.live/owners/dashboard');
-    });
-
-    it('does not call the network', () => {
-      svc.buildAuthorizeUrl('owner-123');
       expect(fetchFn).not.toHaveBeenCalled();
     });
   });
 
   describe('acceptAgreement', () => {
-    it('POSTs the agreement version with bearer auth', async () => {
-      fetchFn.mockResolvedValue(jsonResponse({ version: 'v1' }));
-      const result = await svc.acceptAgreement('owner-123', 'v1');
+    it('POSTs agreement_version (+ ip) and parses agreement_version_accepted', async () => {
+      fetchFn.mockResolvedValue(
+        jsonResponse({ recipient_key: 'owner-123', agreement_version_accepted: 'v1', agreement_accepted_at: 1784445133 }),
+      );
+      const result = await svc.acceptAgreement('owner-123', 'v1', '1.2.3.4');
 
-      expect(fetchFn).toHaveBeenCalledTimes(1);
       const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit];
       expect(url).toBe('https://relay.test/connect/fieldview/recipients/owner-123/agreement');
       expect(init.method).toBe('POST');
       expect((init.headers as Record<string, string>).Authorization).toBe('Bearer nsins_dk_test');
-      expect(JSON.parse(init.body as string)).toEqual({ version: 'v1' });
-      expect(result).toEqual({ accepted: true, version: 'v1' });
+      expect(JSON.parse(init.body as string)).toEqual({ agreement_version: 'v1', ip: '1.2.3.4' });
+      expect(result).toEqual({ accepted: true, version: 'v1', acceptedAt: 1784445133 });
     });
 
-    it('throws when the relay rejects', async () => {
-      fetchFn.mockResolvedValue(jsonResponse({}, false));
-      await expect(svc.acceptAgreement('owner-123', 'v1')).rejects.toThrow(/agreement/i);
+    it('surfaces the relay error code on a stale agreement (428)', async () => {
+      fetchFn.mockResolvedValue(jsonResponse({ error: 'stale', code: 'AGREEMENT_STALE' }, false, 428));
+      await expect(svc.acceptAgreement('owner-123', 'v0')).rejects.toThrow(/AGREEMENT_STALE/);
     });
   });
 
   describe('getFrontendConfig', () => {
-    it('maps snake_case relay fields', async () => {
-      fetchFn.mockResolvedValue(
-        jsonResponse({ application_id: 'sq0idp-abc', environment: 'production', location_id: 'LOC1' }),
-      );
+    it('maps application_id + environment', async () => {
+      fetchFn.mockResolvedValue(jsonResponse({ application_id: 'sq0idp-abc', environment: 'production' }));
       const cfg = await svc.getFrontendConfig('owner-123');
-      expect(cfg).toEqual({ applicationId: 'sq0idp-abc', environment: 'production', locationId: 'LOC1' });
+      expect(cfg).toEqual({ applicationId: 'sq0idp-abc', environment: 'production' });
     });
 
-    it('defaults environment to sandbox and accepts camelCase', async () => {
-      fetchFn.mockResolvedValue(jsonResponse({ applicationId: 'sandbox-sq0idb-x' }));
-      const cfg = await svc.getFrontendConfig('owner-123');
-      expect(cfg.environment).toBe('sandbox');
-      expect(cfg.applicationId).toBe('sandbox-sq0idb-x');
+    it('defaults environment to sandbox', async () => {
+      fetchFn.mockResolvedValue(jsonResponse({ application_id: 'sandbox-sq0idb-x' }));
+      expect((await svc.getFrontendConfig('owner-123')).environment).toBe('sandbox');
     });
 
     it('throws when application_id is missing', async () => {
@@ -94,26 +80,52 @@ describe('RelayConnectHubService', () => {
   });
 
   describe('getRecipientStatus', () => {
-    it('reports connected when frontend-config resolves', async () => {
-      fetchFn.mockResolvedValue(jsonResponse({ application_id: 'sq0idp-abc', environment: 'sandbox' }));
+    it('reports connected with merchant_id from GET /recipients/:key', async () => {
+      fetchFn.mockResolvedValue(
+        jsonResponse({ merchant_id: 'MLEXHMZCYM5EH', connected_at: '2026-07-19T07:57:15Z', agreement_version_accepted: 'v1' }),
+      );
       const status = await svc.getRecipientStatus('owner-123');
-      expect(status).toEqual({ connected: true, recipientKey: 'owner-123' });
+      const [url] = fetchFn.mock.calls[0] as [string];
+      expect(url).toBe('https://relay.test/connect/fieldview/recipients/owner-123');
+      expect(status).toEqual({
+        connected: true,
+        recipientKey: 'owner-123',
+        merchantId: 'MLEXHMZCYM5EH',
+        connectedAt: '2026-07-19T07:57:15Z',
+        agreementVersionAccepted: 'v1',
+      });
     });
 
-    it('reports not connected when the relay errors', async () => {
-      fetchFn.mockResolvedValue(jsonResponse({}, false));
+    it('reports not connected when merchant_id is null (OAuth incomplete)', async () => {
+      fetchFn.mockResolvedValue(jsonResponse({ merchant_id: null, agreement_version_accepted: 'v1' }));
       const status = await svc.getRecipientStatus('owner-123');
-      expect(status).toEqual({ connected: false, recipientKey: 'owner-123' });
+      expect(status.connected).toBe(false);
+      expect(status.merchantId).toBeNull();
+    });
+
+    it('reports not connected when the recipient is unknown (non-ok)', async () => {
+      fetchFn.mockResolvedValue(jsonResponse({ code: 'RECIPIENT_NOT_FOUND' }, false, 404));
+      expect((await svc.getRecipientStatus('nope')).connected).toBe(false);
     });
   });
 
   describe('charge', () => {
-    it('POSTs documented fields and parses the payment result', async () => {
+    it('POSTs documented fields and parses the { payment } envelope', async () => {
       fetchFn.mockResolvedValue(
-        jsonResponse({ payment_id: 'pay_1', status: 'COMPLETED', amount_cents: 1000, app_fee_cents: 100 }),
+        jsonResponse({
+          payment: {
+            id: 'NclJ2yPEO90UerN9PFgB3Iv9B5HZY',
+            status: 'COMPLETED',
+            amount_money: { amount: 1000, currency: 'USD' },
+            app_fee_money: { amount: 100, currency: 'USD' },
+            card_details: { card: { card_brand: 'VISA', last_4: '9259' } },
+            receipt_url: 'https://squareup.com/receipt/preview/NclJ',
+            reference_id: 'purchase-1',
+          },
+        }),
       );
       const result = await svc.charge('owner-123', {
-        sourceId: 'cnon_test',
+        sourceId: 'cnon:test',
         amountCents: 1000,
         idempotencyKey: 'purchase-1',
         note: 'TCHS vs Nelson',
@@ -123,39 +135,53 @@ describe('RelayConnectHubService', () => {
 
       const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit];
       expect(url).toBe('https://relay.test/connect/fieldview/recipients/owner-123/charge');
-      expect(init.method).toBe('POST');
       const sent = JSON.parse(init.body as string) as Record<string, unknown>;
-      expect(sent).toMatchObject({
-        source_id: 'cnon_test',
+      expect(sent).toEqual({
+        source_id: 'cnon:test',
         amount_cents: 1000,
-        currency: 'USD',
         idempotency_key: 'purchase-1',
         note: 'TCHS vs Nelson',
         reference_id: 'purchase-1',
         buyer_email_address: 'fan@example.com',
       });
-      expect(result).toMatchObject({ paymentId: 'pay_1', status: 'COMPLETED', amountCents: 1000, appFeeCents: 100 });
-      expect(result.raw).toMatchObject({ payment_id: 'pay_1' });
+      expect(sent).not.toHaveProperty('currency');
+      expect(result).toMatchObject({
+        paymentId: 'NclJ2yPEO90UerN9PFgB3Iv9B5HZY',
+        status: 'COMPLETED',
+        amountCents: 1000,
+        appFeeCents: 100,
+        cardBrand: 'VISA',
+        cardLast4: '9259',
+        receiptUrl: 'https://squareup.com/receipt/preview/NclJ',
+      });
     });
 
-    it('sends app_fee_bps override when provided', async () => {
-      fetchFn.mockResolvedValue(jsonResponse({ payment_id: 'pay_2', status: 'COMPLETED' }));
+    it('sends app_fee_bps only when overriding', async () => {
+      fetchFn.mockResolvedValue(jsonResponse({ payment: { id: 'p2', status: 'COMPLETED' } }));
       await svc.charge('owner-123', { sourceId: 's', amountCents: 500, idempotencyKey: 'p2', appFeeBps: 500 });
       const sent = JSON.parse((fetchFn.mock.calls[0] as [string, RequestInit])[1].body as string) as Record<string, unknown>;
       expect(sent.app_fee_bps).toBe(500);
     });
 
-    it('throws when the charge is rejected', async () => {
-      fetchFn.mockResolvedValue(jsonResponse({}, false));
+    it('surfaces the Square decline detail on failure', async () => {
+      fetchFn.mockResolvedValue(
+        jsonResponse(
+          { error: 'Payment failed', code: 'CHARGE_FAILED', squareErrors: [{ code: 'CARD_DECLINED', detail: 'The card was declined' }] },
+          false,
+          502,
+        ),
+      );
       await expect(
         svc.charge('owner-123', { sourceId: 's', amountCents: 500, idempotencyKey: 'p3' }),
-      ).rejects.toThrow(/charge/i);
+      ).rejects.toThrow(/The card was declined \[CARD_DECLINED\]/);
     });
   });
 
   describe('refund', () => {
-    it('POSTs the refund and parses the result', async () => {
-      fetchFn.mockResolvedValue(jsonResponse({ refund_id: 'ref_1', status: 'PENDING', amount_cents: 400 }));
+    it('POSTs the refund and parses the { refund } envelope', async () => {
+      fetchFn.mockResolvedValue(
+        jsonResponse({ refund: { id: 'ref_1', status: 'PENDING', amount_money: { amount: 400, currency: 'USD' } } }),
+      );
       const result = await svc.refund('owner-123', {
         paymentId: 'pay_1',
         amountCents: 400,
@@ -165,7 +191,7 @@ describe('RelayConnectHubService', () => {
 
       const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit];
       expect(url).toBe('https://relay.test/connect/fieldview/recipients/owner-123/refunds');
-      expect(JSON.parse(init.body as string)).toMatchObject({
+      expect(JSON.parse(init.body as string)).toEqual({
         payment_id: 'pay_1',
         amount_cents: 400,
         idempotency_key: 'r1',
@@ -174,11 +200,17 @@ describe('RelayConnectHubService', () => {
       expect(result).toMatchObject({ refundId: 'ref_1', status: 'PENDING', amountCents: 400 });
     });
 
-    it('throws when the refund is rejected', async () => {
-      fetchFn.mockResolvedValue(jsonResponse({}, false));
+    it('surfaces the relay error on refund failure', async () => {
+      fetchFn.mockResolvedValue(
+        jsonResponse(
+          { error: 'refund failed', code: 'REFUND_FAILED', squareErrors: [{ code: 'REFUND_ALREADY_PENDING', detail: 'already pending' }] },
+          false,
+          400,
+        ),
+      );
       await expect(
         svc.refund('owner-123', { paymentId: 'pay_1', amountCents: 400, idempotencyKey: 'r2' }),
-      ).rejects.toThrow(/refund/i);
+      ).rejects.toThrow(/REFUND_ALREADY_PENDING/);
     });
   });
 });


### PR DESCRIPTION
Corrects the relay Connect Hub client to the **verified live contract** — read from the private relay repo (`rvegajr/noctusoft-relay` `connect/docs/INTEGRATION.md`) plus the captured 2026-07-19 production canary responses. Slices 1/2 had guessed shapes; this fixes them before any live wiring.

## Fixes
- **charge** → parses `{ payment: {...} }` (id, status, `amount_money.amount`, `app_fee_money.amount`, card brand/last4, receipt_url)
- **refund** → parses `{ refund: {...} }`
- **agreement** → POSTs `{ agreement_version, ip }`, reads `agreement_version_accepted`
- **status** → `GET /recipients/:key` (connected = `merchant_id` present), not frontend-config
- **errors** → surfaces `{ code, squareErrors[].detail }` (e.g. `CARD_DECLINED`, `AGREEMENT_STALE`)
- **frontend-config** → `{ application_id, environment }` only; `locationId` comes from FieldView (relay doesn't return it)
- charge omits `currency` (relay defaults USD); sends `app_fee_bps` only to override the product's configured 10%

## Verification
api type-check 0 errors · build ✅ · **14/14** unit tests. Still additive — no live payment path wired yet (that's the next PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)