### PR TITLE
feat(payments): Slice A — coach relay onboarding UX + locationId capture

### DIFF
--- a/apps/api/src/routes/owners.payments.ts
+++ b/apps/api/src/routes/owners.payments.ts
@@ -149,6 +149,38 @@ router.get('/me/payments/status', requireOwnerAuth, (req: AuthRequest, res, next
   })();
 });
 
+const LocationSchema = z.object({ locationId: z.string().min(1) });
+
+/**
+ * POST /api/owners/me/payments/location
+ *
+ * Stores the coach's own Square location id (the relay does not provide it; it is
+ * required by the Web Payments SDK at checkout). Reuses OwnerAccount.squareLocationId.
+ */
+router.post(
+  '/me/payments/location',
+  requireOwnerAuth,
+  validateRequest({ body: LocationSchema }),
+  (req: AuthRequest, res, next) => {
+    void (async () => {
+      try {
+        if (!req.ownerAccountId) return next(new UnauthorizedError('Owner account ID not found'));
+
+        const repo = new OwnerAccountRepository(prisma);
+        const owner = await repo.findById(req.ownerAccountId);
+        if (!owner) return next(new NotFoundError('Owner account not found'));
+
+        const locationId = (req.body as { locationId: string }).locationId.trim();
+        await repo.update(owner.id, { squareLocationId: locationId });
+
+        res.json({ locationId });
+      } catch (error) {
+        next(error);
+      }
+    })();
+  },
+);
+
 export function createOwnersPaymentsRouter(): Router {
   return router;
 }

--- a/apps/web/__tests__/unit/lib/api-client.test.ts
+++ b/apps/web/__tests__/unit/lib/api-client.test.ts
@@ -70,6 +70,86 @@ describe('api-client', () => {
     const url = fetchMock.mock.calls[0]?.[0] as string;
     expect(url).toContain('/api/public/saved-payments?purchaseId=purchase-123');
   });
+
+  it('ownerPaymentsStatus GETs status with bearer token', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        recipientKey: 'owner-1',
+        merchantId: 'ML1',
+        agreementAccepted: true,
+        agreementVersion: 'v1',
+        connected: true,
+        connectedAt: '2026-07-20T00:00:00Z',
+      }),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    global.fetch = fetchMock as any;
+
+    const result = await apiClient.ownerPaymentsStatus('owner_token_abc');
+
+    const url = fetchMock.mock.calls[0]?.[0] as string;
+    const init = fetchMock.mock.calls[0]?.[1];
+    expect(url).toContain('/api/owners/me/payments/status');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(init?.headers?.Authorization).toBe('Bearer owner_token_abc');
+    expect(result.connected).toBe(true);
+    expect(result.merchantId).toBe('ML1');
+  });
+
+  it('ownerPaymentsConnect POSTs and returns the authorize URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ authorizeUrl: 'https://relay/authorize', recipientKey: 'owner-1' }),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    global.fetch = fetchMock as any;
+
+    const result = await apiClient.ownerPaymentsConnect('owner_token_abc');
+
+    const url = fetchMock.mock.calls[0]?.[0] as string;
+    const init = fetchMock.mock.calls[0]?.[1];
+    expect(url).toContain('/api/owners/me/payments/connect');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(init?.method).toBe('POST');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(init?.headers?.Authorization).toBe('Bearer owner_token_abc');
+    expect(result.authorizeUrl).toBe('https://relay/authorize');
+  });
+
+  it('ownerAcceptAgreement POSTs the version', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ accepted: true, version: 'v1' }),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    global.fetch = fetchMock as any;
+
+    await apiClient.ownerAcceptAgreement('owner_token_abc', 'v1');
+
+    const init = fetchMock.mock.calls[0]?.[1];
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(JSON.parse(init?.body as string)).toEqual({ version: 'v1' });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(init?.headers?.Authorization).toBe('Bearer owner_token_abc');
+  });
+
+  it('ownerSetPaymentLocation POSTs the locationId', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ locationId: 'LOC1' }),
+    });
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    global.fetch = fetchMock as any;
+
+    await apiClient.ownerSetPaymentLocation('owner_token_abc', 'LOC1');
+
+    const url = fetchMock.mock.calls[0]?.[0] as string;
+    const init = fetchMock.mock.calls[0]?.[1];
+    expect(url).toContain('/api/owners/me/payments/location');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    expect(JSON.parse(init?.body as string)).toEqual({ locationId: 'LOC1' });
+  });
 });
 
 

--- a/apps/web/app/owners/dashboard/page.tsx
+++ b/apps/web/app/owners/dashboard/page.tsx
@@ -189,6 +189,34 @@ export default function OwnerDashboardPage() {
             </CardContent>
           </Card>
 
+          <Card className="card-interactive" data-testid="card-payments">
+            <CardHeader className="pb-3">
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 sm:w-12 sm:h-12 rounded-lg bg-primary/10 flex items-center justify-center shrink-0">
+                  <svg className="w-5 h-5 sm:w-6 sm:h-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                </div>
+                <div>
+                  <CardTitle className="text-base sm:text-lg">Payouts</CardTitle>
+                  <CardDescription className="text-xs sm:text-sm">Connect Square &amp; receive payouts</CardDescription>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent className="pt-0">
+              <a
+                href="/owners/payments"
+                className="inline-flex items-center gap-1 text-sm sm:text-base text-primary font-medium hover:underline"
+                data-testid="link-payments"
+              >
+                Manage payouts
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                </svg>
+              </a>
+            </CardContent>
+          </Card>
+
           <Card className="card-interactive" data-testid="card-analytics">
             <CardHeader className="pb-3">
               <div className="flex items-center gap-3">

--- a/apps/web/app/owners/payments/__tests__/page.test.tsx
+++ b/apps/web/app/owners/payments/__tests__/page.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const push = vi.fn();
+const replace = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push, replace }),
+  useSearchParams: () => new URLSearchParams(''),
+}));
+
+vi.mock('@/lib/api-client', () => ({
+  apiClient: {
+    ownerPaymentsStatus: vi.fn(),
+    ownerPaymentsConnect: vi.fn(),
+    ownerAcceptAgreement: vi.fn(),
+    ownerSetPaymentLocation: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/api-client';
+import OwnerPaymentsPage from '../page';
+
+// jsdom's localStorage is not fully implemented in this setup; use a Map-backed mock.
+const store = new Map<string, string>();
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+  },
+});
+
+type Status = {
+  recipientKey: string | null;
+  merchantId: string | null;
+  agreementAccepted: boolean;
+  agreementVersion: string | null;
+  connected: boolean;
+  connectedAt: string | null;
+};
+
+const status = (over: Partial<Status> = {}): Status => ({
+  recipientKey: 'owner-1',
+  merchantId: null,
+  agreementAccepted: true,
+  agreementVersion: 'v1',
+  connected: false,
+  connectedAt: null,
+  ...over,
+});
+
+function clearOwnerToken() {
+  localStorage.removeItem('owner_token');
+  localStorage.removeItem('owner_token_expires');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearOwnerToken();
+  localStorage.setItem('owner_token', 't');
+  localStorage.setItem('owner_token_expires', new Date(Date.now() + 3_600_000).toISOString());
+});
+
+describe('OwnerPaymentsPage', () => {
+  it('redirects to login when there is no owner token', async () => {
+    clearOwnerToken();
+    render(<OwnerPaymentsPage />);
+    await waitFor(() => expect(replace).toHaveBeenCalledWith('/owners/login'));
+  });
+
+  it('shows the agreement step when the agreement is not yet accepted', async () => {
+    vi.mocked(apiClient.ownerPaymentsStatus).mockResolvedValue(status({ agreementAccepted: false }));
+    render(<OwnerPaymentsPage />);
+    expect(await screen.findByTestId('card-agreement')).toBeInTheDocument();
+  });
+
+  it('accepting the agreement calls the API and refetches', async () => {
+    vi.mocked(apiClient.ownerPaymentsStatus)
+      .mockResolvedValueOnce(status({ agreementAccepted: false }))
+      .mockResolvedValueOnce(status({ agreementAccepted: true }));
+    vi.mocked(apiClient.ownerAcceptAgreement).mockResolvedValue({ accepted: true, version: 'v1' });
+
+    render(<OwnerPaymentsPage />);
+    await userEvent.click(await screen.findByTestId('btn-accept-agreement'));
+    await waitFor(() => expect(apiClient.ownerAcceptAgreement).toHaveBeenCalledWith('t', undefined));
+  });
+
+  it('the connect step calls ownerPaymentsConnect', async () => {
+    vi.mocked(apiClient.ownerPaymentsStatus).mockResolvedValue(status({ agreementAccepted: true, connected: false }));
+    vi.mocked(apiClient.ownerPaymentsConnect).mockResolvedValue({ authorizeUrl: 'https://relay/authz', recipientKey: 'owner-1' });
+
+    render(<OwnerPaymentsPage />);
+    await userEvent.click(await screen.findByTestId('btn-connect-payments'));
+    await waitFor(() => expect(apiClient.ownerPaymentsConnect).toHaveBeenCalledWith('t'));
+  });
+
+  it('the connected state saves the Square location id', async () => {
+    vi.mocked(apiClient.ownerPaymentsStatus).mockResolvedValue(
+      status({ merchantId: 'ML1', connected: true, connectedAt: '2026-07-20T00:00:00Z' }),
+    );
+    vi.mocked(apiClient.ownerSetPaymentLocation).mockResolvedValue({ locationId: 'LOC1' });
+
+    render(<OwnerPaymentsPage />);
+    await userEvent.type(await screen.findByTestId('input-location-id'), 'LOC1');
+    await userEvent.click(screen.getByTestId('btn-save-location'));
+    await waitFor(() => expect(apiClient.ownerSetPaymentLocation).toHaveBeenCalledWith('t', 'LOC1'));
+  });
+});

--- a/apps/web/app/owners/payments/page.tsx
+++ b/apps/web/app/owners/payments/page.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import { Suspense, useCallback, useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { ErrorBanner } from '@/components/v2/ErrorBanner';
+import { apiClient, type OwnerPaymentsStatus } from '@/lib/api-client';
+
+function getOwnerToken(): string | null {
+  return typeof window === 'undefined' ? null : localStorage.getItem('owner_token');
+}
+
+function PaymentsInner() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [authenticated, setAuthenticated] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<OwnerPaymentsStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [locationId, setLocationId] = useState('');
+  const [justConnected, setJustConnected] = useState(false);
+
+  const fetchStatus = useCallback(async () => {
+    const token = getOwnerToken();
+    if (!token) return;
+    setLoading(true);
+    setError(null);
+    try {
+      setStatus(await apiClient.ownerPaymentsStatus(token));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load payments status');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const token = localStorage.getItem('owner_token');
+    const expires = localStorage.getItem('owner_token_expires');
+    if (!token || (expires && new Date(expires) < new Date())) {
+      router.replace('/owners/login');
+      return;
+    }
+    setAuthenticated(true);
+    if (searchParams.get('payments_connected') === 'true') setJustConnected(true);
+  }, [router, searchParams]);
+
+  useEffect(() => {
+    if (authenticated) void fetchStatus();
+  }, [authenticated, fetchStatus]);
+
+  async function handleAcceptAgreement() {
+    const token = getOwnerToken();
+    if (!token) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await apiClient.ownerAcceptAgreement(token, undefined);
+      await fetchStatus();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to record agreement');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleConnect() {
+    const token = getOwnerToken();
+    if (!token) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const resp = await apiClient.ownerPaymentsConnect(token);
+      window.location.href = resp.authorizeUrl;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to start Square connection');
+      setBusy(false);
+    }
+  }
+
+  async function handleSaveLocation() {
+    const token = getOwnerToken();
+    if (!token || !locationId.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await apiClient.ownerSetPaymentLocation(token, locationId.trim());
+      await fetchStatus();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to save location');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function logout() {
+    localStorage.removeItem('owner_token');
+    localStorage.removeItem('owner_token_expires');
+    router.push('/owners/login');
+  }
+
+  if (!authenticated) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <p>Loading…</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <div className="container mx-auto max-w-6xl px-4 sm:px-6 py-3 sm:py-4">
+          <div className="flex items-center justify-between gap-4">
+            <div className="min-w-0">
+              <h1 className="text-xl sm:text-2xl font-semibold truncate">Payouts</h1>
+              <p className="text-xs sm:text-sm text-muted-foreground hidden sm:block">
+                Connect your Square account to receive payouts for your streams
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button variant="ghost" size="sm" onClick={() => router.push('/owners/dashboard')}>
+                Dashboard
+              </Button>
+              <Button variant="outline" onClick={logout} aria-label="Sign out" className="shrink-0">
+                <span className="hidden sm:inline">Sign out</span>
+                <span className="sm:hidden">✕</span>
+              </Button>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main className="container mx-auto max-w-6xl px-4 sm:px-6 py-6 sm:py-8 space-y-6">
+        {error && <ErrorBanner message={error} onDismiss={() => setError(null)} data-testid="payments-error" />}
+
+        {justConnected && (
+          <div className="rounded-lg bg-green-50 border border-green-200 p-4 text-green-800 text-sm">
+            Square account connected! Add your Location ID below to finish.
+          </div>
+        )}
+
+        {loading ? (
+          <div className="text-center py-12">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto"></div>
+            <p className="mt-4 text-muted-foreground">Loading payouts status…</p>
+          </div>
+        ) : status && !status.agreementAccepted ? (
+          <Card data-testid="card-agreement">
+            <CardHeader>
+              <CardTitle>Accept the Recipient Agreement</CardTitle>
+              <CardDescription>
+                Before connecting Square, please review and accept the{' '}
+                <a href="/legal/recipient-agreement" className="underline" target="_blank" rel="noreferrer">
+                  Recipient Agreement
+                </a>
+                . This covers how payouts and the platform fee work.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button onClick={handleAcceptAgreement} disabled={busy} data-testid="btn-accept-agreement">
+                {busy ? 'Saving…' : 'Accept & Continue'}
+              </Button>
+            </CardContent>
+          </Card>
+        ) : status && !status.connected ? (
+          <Card>
+            <CardHeader>
+              <CardTitle>Connect Square</CardTitle>
+              <CardDescription>
+                Connect your own Square account to receive payouts. Viewers&apos; payments go directly to your Square
+                balance; FieldView keeps a small platform fee. You&apos;ll be redirected to Square to authorize.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="rounded-lg bg-muted/50 p-4">
+                <h3 className="font-medium mb-2">How it works</h3>
+                <ul className="text-sm text-muted-foreground space-y-1">
+                  <li>1. Click &quot;Connect Square&quot; below</li>
+                  <li>2. Authorize FieldView on Square&apos;s website</li>
+                  <li>3. You&apos;ll be redirected back here</li>
+                  <li>4. Add your Square Location ID to finish</li>
+                </ul>
+              </div>
+              <Button onClick={handleConnect} disabled={busy} className="w-full sm:w-auto" data-testid="btn-connect-payments">
+                {busy ? 'Redirecting to Square…' : 'Connect Square'}
+              </Button>
+            </CardContent>
+          </Card>
+        ) : status ? (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-green-600">Connected</CardTitle>
+              <CardDescription>Your Square account is connected. Payouts settle directly to your Square balance.</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                <div className="rounded-lg bg-muted/50 p-3">
+                  <div className="text-xs text-muted-foreground">Merchant ID</div>
+                  <div className="font-mono text-sm">{status.merchantId || '—'}</div>
+                </div>
+                <div className="rounded-lg bg-muted/50 p-3">
+                  <div className="text-xs text-muted-foreground">Connected</div>
+                  <div className="text-sm">
+                    {status.connectedAt ? new Date(status.connectedAt).toLocaleDateString() : '—'}
+                  </div>
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="location-id">Square Location ID</Label>
+                <p className="text-xs text-muted-foreground">
+                  Find this in your Square Dashboard → Account &amp; Settings → Locations. Required for checkout.
+                </p>
+                <div className="flex flex-col sm:flex-row gap-2">
+                  <Input
+                    id="location-id"
+                    data-testid="input-location-id"
+                    placeholder="e.g. LSWR97SDRBXWK"
+                    value={locationId}
+                    onChange={(e) => setLocationId(e.target.value)}
+                    className="sm:max-w-xs"
+                  />
+                  <Button onClick={handleSaveLocation} disabled={busy || !locationId.trim()} data-testid="btn-save-location">
+                    {busy ? 'Saving…' : 'Save Location'}
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ) : null}
+      </main>
+    </div>
+  );
+}
+
+export default function OwnerPaymentsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-background flex items-center justify-center">
+          <p>Loading…</p>
+        </div>
+      }
+    >
+      <PaymentsInner />
+    </Suspense>
+  );
+}

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -134,6 +134,16 @@ function withBearerToken(token: string | null | undefined): HeadersInit | undefi
   return { Authorization: `Bearer ${token}` };
 }
 
+// Owner relay-payments (Connect Hub) onboarding status
+export interface OwnerPaymentsStatus {
+  recipientKey: string | null;
+  merchantId: string | null;
+  agreementAccepted: boolean;
+  agreementVersion: string | null;
+  connected: boolean;
+  connectedAt: string | null;
+}
+
 // Game types
 export interface Game {
   id: string;
@@ -792,5 +802,37 @@ export const apiClient = {
         body: JSON.stringify(data),
       }
     );
+  },
+
+  /**
+   * Owner relay-payments (Connect Hub) onboarding — all require the owner token.
+   */
+  async ownerPaymentsStatus(ownerToken: string): Promise<OwnerPaymentsStatus> {
+    return apiRequest<OwnerPaymentsStatus>(`/api/owners/me/payments/status`, {
+      headers: { ...withBearerToken(ownerToken) },
+    });
+  },
+
+  async ownerPaymentsConnect(ownerToken: string): Promise<{ authorizeUrl: string; recipientKey: string }> {
+    return apiRequest<{ authorizeUrl: string; recipientKey: string }>(`/api/owners/me/payments/connect`, {
+      method: 'POST',
+      headers: { ...withBearerToken(ownerToken) },
+    });
+  },
+
+  async ownerAcceptAgreement(ownerToken: string, version?: string): Promise<{ accepted: boolean; version: string }> {
+    return apiRequest<{ accepted: boolean; version: string }>(`/api/owners/me/payments/agreement`, {
+      method: 'POST',
+      headers: { ...withBearerToken(ownerToken) },
+      body: JSON.stringify({ version }),
+    });
+  },
+
+  async ownerSetPaymentLocation(ownerToken: string, locationId: string): Promise<{ locationId: string }> {
+    return apiRequest<{ locationId: string }>(`/api/owners/me/payments/location`, {
+      method: 'POST',
+      headers: { ...withBearerToken(ownerToken) },
+      body: JSON.stringify({ locationId }),
+    });
   },
 };


### PR DESCRIPTION
**Slice A** of the approved Connect Hub completion plan — coach onboarding UX. Additive; no production behavior change.

## Adds
- **Owner 'Payouts' page** `app/owners/payments/page.tsx`: agreement → connect (relay authorize redirect) → status → capture the coach's Square **locationId** (the relay doesn't return it; the Web SDK needs it). Cloned from `owners/square`, uses `apiClient` + shadcn `ui/*` + `ErrorBanner`.
- **api-client**: `ownerPaymentsStatus/Connect/AcceptAgreement/SetPaymentLocation` (+ `OwnerPaymentsStatus`), `withBearerToken` pattern.
- **Backend**: `POST /api/owners/me/payments/location` → `OwnerAccount.squareLocationId`.
- **Dashboard**: `card-payments` → `/owners/payments`.

## TDD + verification
Tests written first: **api-client (4)** + **owners/payments page (5)**, all green. api type-check **0 errors**, web **build ✅** (`/owners/payments` compiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)