### PR TITLE
feat(payments): Slice C.1 — RefundService relay-refund branch

### DIFF
--- a/apps/api/src/services/RefundService.ts
+++ b/apps/api/src/services/RefundService.ts
@@ -6,13 +6,16 @@
  */
 
 import { BadRequestError, NotFoundError } from '../lib/errors';
+import { isPaymentsViaRelay } from '../lib/relay';
 import { squareClient } from '../lib/square';
+import type { IOwnerAccountReader } from '../repositories/IOwnerAccountRepository';
 import type { IPlaybackSessionReader } from '../repositories/IPlaybackSessionRepository';
 import type { IPurchaseReader, IPurchaseWriter } from '../repositories/IPurchaseRepository';
 import type { IRefundReader as IRefundRepoReader, IRefundWriter as IRefundRepoWriter } from '../repositories/IRefundRepository';
 import { calculateRefund, type RefundCalculationInput } from '../utils/refundCalculator';
 
 import type { IEntitlementReader } from './IEntitlementService';
+import type { IRelayConnectPayments } from './IRelayConnectHubService';
 import type { IRefundReader, IRefundWriter, AggregatedTelemetry, RefundEvaluation } from './IRefundService';
 import type { ISmsWriter } from './ISmsService';
 
@@ -26,7 +29,9 @@ export class RefundService implements IRefundReader, IRefundWriter {
     private refundReader: IRefundRepoReader,
     private refundWriter: IRefundRepoWriter,
     private entitlementReader: IEntitlementReader,
-    private smsWriter: ISmsWriter
+    private smsWriter: ISmsWriter,
+    private ownerReader: IOwnerAccountReader,
+    private relay: IRelayConnectPayments
   ) {}
 
   async evaluateRefundEligibility(purchaseId: string): Promise<RefundEvaluation> {
@@ -192,7 +197,27 @@ export class RefundService implements IRefundReader, IRefundWriter {
       throw new BadRequestError('Purchase has no payment provider ID');
     }
 
-    // Create Square refund
+    // Relay Connect Hub path (flag-gated): refund on the coach's own Square via the
+    // relay, which reverses the app fee proportionally. Falls through to the legacy
+    // central-client path when off or the owner is not migrated.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const relayOwnerId = purchase.recipientOwnerAccountId as string | undefined;
+    if (isPaymentsViaRelay() && relayOwnerId) {
+      const owner = await this.ownerReader.findById(relayOwnerId);
+      if (owner?.relayRecipientKey) {
+        await this.relay.refund(owner.relayRecipientKey, {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          paymentId: purchase.paymentProviderPaymentId as string,
+          amountCents: refund.amountCents,
+          idempotencyKey: `refund-${refundId}`,
+          reason: refund.reasonCode,
+        });
+        await this.refundWriter.update(refundId, { processedAt: new Date() });
+        return;
+      }
+    }
+
+    // Create Square refund (legacy Model A: central platform client)
     try {
       // Square SDK v43+ - refunds API
       // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access

--- a/apps/api/src/services/__tests__/RefundService.test.ts
+++ b/apps/api/src/services/__tests__/RefundService.test.ts
@@ -1,0 +1,94 @@
+/**
+ * RefundService.processSquareRefund — relay vs legacy branch.
+ * ISP deps mocked via vi.fn(); lib/square mocked so the legacy path is inert.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../lib/square', () => ({
+  squareClient: { refundsApi: { refundPayment: vi.fn() } },
+}));
+
+import { RefundService } from '../RefundService';
+import { squareClient } from '../../lib/square';
+
+function build() {
+  const refundReader = { getById: vi.fn(), getByPurchaseId: vi.fn() };
+  const refundWriter = { create: vi.fn(), update: vi.fn() };
+  const ownerReader = { findById: vi.fn(), findByContactEmail: vi.fn() };
+  const relay = { charge: vi.fn(), refund: vi.fn() };
+  const svc = new RefundService(
+    { getById: vi.fn() } as never,
+    { update: vi.fn() } as never,
+    {} as never,
+    refundReader as never,
+    refundWriter as never,
+    {} as never,
+    {} as never,
+    ownerReader as never,
+    relay as never,
+  );
+  return { svc, refundReader, refundWriter, ownerReader, relay };
+}
+
+const refundRow = (over: Record<string, unknown> = {}) => ({
+  id: 'refund-1',
+  amountCents: 500,
+  reasonCode: 'buffering',
+  processedAt: null,
+  purchase: { recipientOwnerAccountId: 'owner-1', paymentProviderPaymentId: 'pay_1', currency: 'USD' },
+  ...over,
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+const refundPaymentMock = (squareClient as any).refundsApi.refundPayment as ReturnType<typeof vi.fn>;
+
+describe('RefundService.processSquareRefund', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('refunds via the relay when the flag is on and the owner is migrated', async () => {
+    vi.stubEnv('PAYMENTS_VIA_RELAY', 'true');
+    const { svc, refundReader, refundWriter, ownerReader, relay } = build();
+    refundReader.getById.mockResolvedValue(refundRow());
+    ownerReader.findById.mockResolvedValue({ id: 'owner-1', relayRecipientKey: 'owner-1' });
+    relay.refund.mockResolvedValue({ refundId: 'r1', status: 'PENDING', amountCents: 500, raw: {} });
+
+    await svc.processSquareRefund('refund-1');
+
+    expect(relay.refund).toHaveBeenCalledWith('owner-1', {
+      paymentId: 'pay_1',
+      amountCents: 500,
+      idempotencyKey: 'refund-refund-1',
+      reason: 'buffering',
+    });
+    expect(refundWriter.update).toHaveBeenCalledWith('refund-1', { processedAt: expect.any(Date) });
+    expect(refundPaymentMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the central Square client when the owner is not migrated', async () => {
+    vi.stubEnv('PAYMENTS_VIA_RELAY', 'true');
+    const { svc, refundReader, ownerReader, relay } = build();
+    refundReader.getById.mockResolvedValue(refundRow());
+    ownerReader.findById.mockResolvedValue({ id: 'owner-1', relayRecipientKey: null });
+
+    await svc.processSquareRefund('refund-1');
+
+    expect(relay.refund).not.toHaveBeenCalled();
+    expect(refundPaymentMock).toHaveBeenCalled();
+  });
+
+  it('does not touch the relay when the flag is off', async () => {
+    const { svc, refundReader, ownerReader, relay } = build();
+    refundReader.getById.mockResolvedValue(refundRow());
+
+    await svc.processSquareRefund('refund-1');
+
+    expect(relay.refund).not.toHaveBeenCalled();
+    expect(ownerReader.findById).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
**Slice C.1** — makes `RefundService` relay-aware (foundation for the admin issue-refund route). Additive; flag-gated.

- `processSquareRefund` → `RelayConnectHubService.refund` when `PAYMENTS_VIA_RELAY` + owner has `relayRecipientKey`; else legacy central client. ISP: injects `IRelayConnectPayments` + `IOwnerAccountReader`.
- `RefundService` was uncalled dead code → no callers change.

**TDD:** `RefundService.test.ts` (relay branch / legacy fallback / flag-off) first, **3/3**. api type-check **0**, build ✅.

Follow-ups in this slice: **C.2** admin `POST /api/admin/purchases/:id/refund` (wires this live) and **C.3** relay inbound webhook (HMAC-verified) — separate PRs for focused review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)