### PR TITLE
feat(payments): Slice C.2 — admin issue-refund route (relay-aware)

### DIFF
--- a/apps/api/src/routes/admin.ts
+++ b/apps/api/src/routes/admin.ts
@@ -24,6 +24,12 @@ import { ViewerIdentityRepository } from '../repositories/implementations/Viewer
 import { AdminAuthService } from '../services/AdminAuthService';
 import { AdminService } from '../services/AdminService';
 import { AudienceService } from '../services/AudienceService';
+import { getRelayConfig } from '../lib/relay';
+import { OwnerAccountRepository } from '../repositories/implementations/OwnerAccountRepository';
+import type { IRefundWriter } from '../services/IRefundService';
+import { RefundService } from '../services/RefundService';
+import { RelayConnectHubService } from '../services/RelayConnectHubService';
+import { SmsService } from '../services/SmsService';
 
 const router = express.Router();
 
@@ -75,6 +81,74 @@ export function setAdminService(service: AdminService): void {
 export function setAdminAuthService(service: AdminAuthService): void {
   adminAuthServiceInstance = service;
 }
+
+let refundServiceInstance: IRefundWriter | null = null;
+
+function getRefundService(): IRefundWriter {
+  if (!refundServiceInstance) {
+    const purchaseRepo = new PurchaseRepository(prisma);
+    const playbackSessionRepo = new PlaybackSessionRepository(prisma);
+    const refundRepo = new RefundRepository(prisma);
+    const entitlementRepo = new EntitlementRepository(prisma);
+    const gameRepo = new GameRepository(prisma);
+    const viewerIdentityRepo = new ViewerIdentityRepository(prisma);
+    const ownerRepo = new OwnerAccountRepository(prisma);
+    const smsService = new SmsService(gameRepo, viewerIdentityRepo, viewerIdentityRepo);
+    const relay = new RelayConnectHubService(getRelayConfig());
+    refundServiceInstance = new RefundService(
+      purchaseRepo,
+      purchaseRepo,
+      playbackSessionRepo,
+      refundRepo,
+      refundRepo,
+      entitlementRepo,
+      smsService,
+      ownerRepo,
+      relay
+    );
+  }
+  return refundServiceInstance;
+}
+
+export function setRefundService(service: IRefundWriter): void {
+  refundServiceInstance = service;
+}
+
+const IssueRefundSchema = z.object({
+  amountCents: z.number().int().positive(),
+  reasonCode: z.string().min(1).optional(),
+});
+
+/**
+ * POST /api/admin/purchases/:purchaseId/refund
+ *
+ * Admin-initiated full/partial refund. Routes to the relay when the owner is
+ * migrated (flag-gated), else the legacy Square path.
+ */
+router.post(
+  '/purchases/:purchaseId/refund',
+  requireAdminAuth,
+  auditLog({ actionType: 'issue_refund', targetType: 'purchase' }),
+  validateRequest({ body: IssueRefundSchema }),
+  (req: AuthRequest, res, next: NextFunction) => {
+    void (async () => {
+      try {
+        const adminId = req.adminUserId || 'admin';
+        const purchaseId = req.params.purchaseId;
+        const { amountCents, reasonCode } = req.body as { amountCents: number; reasonCode?: string };
+        const refund = await getRefundService().issueManualRefund(
+          purchaseId,
+          amountCents,
+          reasonCode || 'admin_manual',
+          adminId
+        );
+        res.json({ refundId: refund.id, amountCents: refund.amountCents, status: 'processing' });
+      } catch (error) {
+        next(error);
+      }
+    })();
+  }
+);
 
 // Validation schemas
 const LoginSchema = z.object({

--- a/apps/api/src/services/IRefundService.ts
+++ b/apps/api/src/services/IRefundService.ts
@@ -50,5 +50,12 @@ export interface IRefundWriter {
     appliedRule: string,
     ruleVersion: string
   ): Promise<Refund>;
+  /** Admin-initiated full/partial refund (not telemetry-gated). */
+  issueManualRefund(
+    purchaseId: string,
+    amountCents: number,
+    reasonCode: string,
+    issuedBy: string
+  ): Promise<Refund>;
   processSquareRefund(refundId: string): Promise<void>;
 }

--- a/apps/api/src/services/RefundService.ts
+++ b/apps/api/src/services/RefundService.ts
@@ -14,7 +14,7 @@ import type { IPurchaseReader, IPurchaseWriter } from '../repositories/IPurchase
 import type { IRefundReader as IRefundRepoReader, IRefundWriter as IRefundRepoWriter } from '../repositories/IRefundRepository';
 import { calculateRefund, type RefundCalculationInput } from '../utils/refundCalculator';
 
-import type { IEntitlementReader } from './IEntitlementService';
+import type { IEntitlementReader as IEntitlementRepoReader } from '../repositories/IEntitlementRepository';
 import type { IRelayConnectPayments } from './IRelayConnectHubService';
 import type { IRefundReader, IRefundWriter, AggregatedTelemetry, RefundEvaluation } from './IRefundService';
 import type { ISmsWriter } from './ISmsService';
@@ -28,7 +28,7 @@ export class RefundService implements IRefundReader, IRefundWriter {
     private playbackSessionReader: IPlaybackSessionReader,
     private refundReader: IRefundRepoReader,
     private refundWriter: IRefundRepoWriter,
-    private entitlementReader: IEntitlementReader,
+    private entitlementReader: IEntitlementRepoReader,
     private smsWriter: ISmsWriter,
     private ownerReader: IOwnerAccountReader,
     private relay: IRelayConnectPayments
@@ -180,6 +180,53 @@ export class RefundService implements IRefundReader, IRefundWriter {
     return refund;
   }
 
+  async issueManualRefund(
+    purchaseId: string,
+    amountCents: number,
+    reasonCode: string,
+    issuedBy: string
+  ): Promise<import('@prisma/client').Refund> {
+    const purchase = await this.purchaseReader.getById(purchaseId);
+    if (!purchase) {
+      throw new NotFoundError('Purchase not found');
+    }
+    const existingRefunds = await this.refundReader.getByPurchaseId(purchaseId);
+    if (existingRefunds.length > 0) {
+      throw new BadRequestError('Purchase already refunded');
+    }
+    if (amountCents <= 0 || amountCents > purchase.amountCents) {
+      throw new BadRequestError('Invalid refund amount');
+    }
+
+    const refund = await this.refundWriter.create({
+      purchaseId,
+      amountCents,
+      reasonCode,
+      issuedBy,
+      ruleVersion: 'manual',
+      telemetrySummary: {
+        watchMs: 0,
+        bufferMs: 0,
+        bufferEvents: 0,
+        fatalErrors: 0,
+        streamDownMs: 0,
+        bufferRatio: 0,
+        downtimeRatio: 0,
+        appliedRule: 'manual',
+      },
+    });
+
+    const isFullRefund = amountCents >= purchase.amountCents;
+    await this.purchaseWriter.update(purchaseId, {
+      status: isFullRefund ? 'refunded' : 'partially_refunded',
+      refundedAt: new Date(),
+    });
+
+    await this.processSquareRefund(refund.id);
+
+    return refund;
+  }
+
   async processSquareRefund(refundId: string): Promise<void> {
     // Get refund
     const refund = await this.refundReader.getById(refundId);
@@ -254,7 +301,7 @@ export class RefundService implements IRefundReader, IRefundWriter {
     // Get entitlement for this purchase (one-to-one relationship)
     // Note: Using getByPurchaseId which returns a single entitlement
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-    const entitlement = await (this.entitlementReader as any).getByPurchaseId(purchaseId);
+    const entitlement = await this.entitlementReader.getByPurchaseId(purchaseId);
     if (!entitlement) {
       return {
         watchMs: 0,

--- a/apps/api/src/services/__tests__/RefundService.test.ts
+++ b/apps/api/src/services/__tests__/RefundService.test.ts
@@ -13,13 +13,15 @@ import { RefundService } from '../RefundService';
 import { squareClient } from '../../lib/square';
 
 function build() {
+  const purchaseReader = { getById: vi.fn() };
+  const purchaseWriter = { update: vi.fn() };
   const refundReader = { getById: vi.fn(), getByPurchaseId: vi.fn() };
   const refundWriter = { create: vi.fn(), update: vi.fn() };
   const ownerReader = { findById: vi.fn(), findByContactEmail: vi.fn() };
   const relay = { charge: vi.fn(), refund: vi.fn() };
   const svc = new RefundService(
-    { getById: vi.fn() } as never,
-    { update: vi.fn() } as never,
+    purchaseReader as never,
+    purchaseWriter as never,
     {} as never,
     refundReader as never,
     refundWriter as never,
@@ -28,7 +30,7 @@ function build() {
     ownerReader as never,
     relay as never,
   );
-  return { svc, refundReader, refundWriter, ownerReader, relay };
+  return { svc, purchaseReader, purchaseWriter, refundReader, refundWriter, ownerReader, relay };
 }
 
 const refundRow = (over: Record<string, unknown> = {}) => ({
@@ -90,5 +92,48 @@ describe('RefundService.processSquareRefund', () => {
 
     expect(relay.refund).not.toHaveBeenCalled();
     expect(ownerReader.findById).not.toHaveBeenCalled();
+  });
+});
+
+describe('RefundService.issueManualRefund', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('creates a refund, marks the purchase, and processes via the relay', async () => {
+    vi.stubEnv('PAYMENTS_VIA_RELAY', 'true');
+    const { svc, purchaseReader, purchaseWriter, refundReader, refundWriter, ownerReader, relay } = build();
+    purchaseReader.getById.mockResolvedValue({ amountCents: 1000 });
+    refundReader.getByPurchaseId.mockResolvedValue([]);
+    refundWriter.create.mockResolvedValue({ id: 'refund-1', amountCents: 400 });
+    // processSquareRefund reloads the refund with its purchase relation
+    refundReader.getById.mockResolvedValue({
+      id: 'refund-1',
+      amountCents: 400,
+      reasonCode: 'goodwill',
+      processedAt: null,
+      purchase: { recipientOwnerAccountId: 'owner-1', paymentProviderPaymentId: 'pay_1', currency: 'USD' },
+    });
+    ownerReader.findById.mockResolvedValue({ id: 'owner-1', relayRecipientKey: 'owner-1' });
+    relay.refund.mockResolvedValue({ refundId: 'r1', status: 'PENDING', amountCents: 400, raw: {} });
+
+    const result = await svc.issueManualRefund('p1', 400, 'goodwill', 'admin-1');
+
+    expect(refundWriter.create).toHaveBeenCalledWith(
+      expect.objectContaining({ purchaseId: 'p1', amountCents: 400, reasonCode: 'goodwill', issuedBy: 'admin-1', ruleVersion: 'manual' }),
+    );
+    expect(purchaseWriter.update).toHaveBeenCalledWith('p1', expect.objectContaining({ status: 'partially_refunded' }));
+    expect(relay.refund).toHaveBeenCalled();
+    expect(result.id).toBe('refund-1');
+  });
+
+  it('rejects an amount over the purchase total', async () => {
+    const { svc, purchaseReader, refundReader } = build();
+    purchaseReader.getById.mockResolvedValue({ amountCents: 500 });
+    refundReader.getByPurchaseId.mockResolvedValue([]);
+    await expect(svc.issueManualRefund('p1', 999, 'x', 'admin-1')).rejects.toThrow(/Invalid refund amount/);
   });
 });


### PR DESCRIPTION
**Slice C.2** — makes refunds usable: an admin can issue a full/partial refund that routes through the relay.

- **`RefundService.issueManualRefund`** (not telemetry-gated) → creates the refund, marks the purchase, processes via the C.1 relay branch (or legacy).
- **`POST /api/admin/purchases/:id/refund`** (admin-auth + audit) + `setRefundService` hook.
- Fix: `entitlementReader` typed as the repository reader (matches actual `getByPurchaseId` use; removes an `as any`).

**TDD:** issueManualRefund tests (relay path + amount validation), **5/5**. api type-check **0**, build ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)