### PR TITLE
feat(payments): Slice C.3 — relay inbound webhook (sync to develop)

### DIFF
--- a/apps/api/src/lib/__tests__/relay.test.ts
+++ b/apps/api/src/lib/__tests__/relay.test.ts
@@ -1,0 +1,34 @@
+import crypto from 'crypto';
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import { verifyRelaySignature } from '../relay';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('verifyRelaySignature', () => {
+  const url = 'https://fieldview.live/api/webhooks/relay';
+  const body = '{"type":"refund.updated"}';
+  const sign = (secret: string) => crypto.createHmac('sha256', secret).update(url + body).digest('base64');
+
+  it('returns true for a valid signature', () => {
+    vi.stubEnv('FIELDVIEW_WEBHOOK_SECRET', 's3cret');
+    expect(verifyRelaySignature(sign('s3cret'), body, url)).toBe(true);
+  });
+
+  it('returns false for a wrong signature', () => {
+    vi.stubEnv('FIELDVIEW_WEBHOOK_SECRET', 's3cret');
+    expect(verifyRelaySignature(sign('other-secret'), body, url)).toBe(false);
+  });
+
+  it('returns false when the secret is not configured', () => {
+    expect(verifyRelaySignature(sign('s3cret'), body, url)).toBe(false);
+  });
+
+  it('returns false when the signature header is missing', () => {
+    vi.stubEnv('FIELDVIEW_WEBHOOK_SECRET', 's3cret');
+    expect(verifyRelaySignature(undefined, body, url)).toBe(false);
+  });
+});

--- a/apps/api/src/lib/relay.ts
+++ b/apps/api/src/lib/relay.ts
@@ -7,6 +7,27 @@
  * Square secrets — only the relay deploy key. See docs/RELAY-CONNECT-HUB-MIGRATION.md.
  */
 
+import crypto from 'crypto';
+
+/**
+ * Verify a relay-forwarded webhook. The relay re-signs each event with the
+ * product's own secret: base64( HMAC-SHA256( FIELDVIEW_WEBHOOK_SECRET, callbackUrl + rawBody ) ),
+ * delivered in the `x-connect-signature` header. Constant-time compared.
+ */
+export function verifyRelaySignature(
+  signature: string | undefined,
+  rawBody: string,
+  callbackUrl: string,
+): boolean {
+  const secret = process.env.FIELDVIEW_WEBHOOK_SECRET || '';
+  if (!secret || !signature) return false;
+  const expected = crypto.createHmac('sha256', secret).update(callbackUrl + rawBody).digest('base64');
+  const a = Buffer.from(signature);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
+
 export interface RelayConfig {
   /** e.g. https://api.square.noctusoft.com */
   baseUrl: string;

--- a/apps/api/src/routes/__tests__/webhooks.relay.test.ts
+++ b/apps/api/src/routes/__tests__/webhooks.relay.test.ts
@@ -1,0 +1,74 @@
+import crypto from 'crypto';
+
+import express from 'express';
+import request from 'supertest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { createRelayWebhookRouter, setRelayWebhookHandler } from '../webhooks.relay';
+
+const CALLBACK = 'http://localhost:4301/api/webhooks/relay';
+
+function makeApp() {
+  const a = express();
+  // Replicate the app-wide raw-body capture used for HMAC verification.
+  a.use(
+    express.json({
+      verify: (req, _res, buf) => {
+        (req as unknown as { rawBody?: Buffer }).rawBody = buf;
+      },
+    }),
+  );
+  a.use('/api/webhooks', createRelayWebhookRouter());
+  return a;
+}
+
+const sign = (secret: string, body: string) =>
+  crypto.createHmac('sha256', secret).update(CALLBACK + body).digest('base64');
+
+describe('POST /api/webhooks/relay', () => {
+  beforeEach(() => {
+    vi.stubEnv('FIELDVIEW_WEBHOOK_SECRET', 'whsec');
+    vi.stubEnv('FIELDVIEW_WEBHOOK_CALLBACK_URL', CALLBACK);
+  });
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('accepts a validly-signed event and dispatches it with context', async () => {
+    const handle = vi.fn().mockResolvedValue(undefined);
+    setRelayWebhookHandler({ handle });
+    const payload = JSON.stringify({
+      type: 'refund.updated',
+      data: { object: { refund: { payment_id: 'pay_1', status: 'COMPLETED' } } },
+    });
+
+    const res = await request(makeApp())
+      .post('/api/webhooks/relay')
+      .set('Content-Type', 'application/json')
+      .set('x-connect-signature', sign('whsec', payload))
+      .set('x-connect-product', 'fieldview')
+      .set('x-connect-recipient-key', 'owner-1')
+      .send(payload);
+
+    expect(res.status).toBe(200);
+    expect(handle).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'refund.updated' }),
+      expect.objectContaining({ productKey: 'fieldview', recipientKey: 'owner-1' }),
+    );
+  });
+
+  it('rejects an invalid signature with 401 and does not dispatch', async () => {
+    const handle = vi.fn();
+    setRelayWebhookHandler({ handle });
+    const payload = JSON.stringify({ type: 'refund.updated' });
+
+    const res = await request(makeApp())
+      .post('/api/webhooks/relay')
+      .set('Content-Type', 'application/json')
+      .set('x-connect-signature', sign('wrong-secret', payload))
+      .send(payload);
+
+    expect(res.status).toBe(401);
+    expect(handle).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/routes/webhooks.relay.ts
+++ b/apps/api/src/routes/webhooks.relay.ts
@@ -1,0 +1,110 @@
+/**
+ * Relay Connect Hub inbound webhook.
+ *
+ * The relay verifies Square's platform webhook, then re-signs each event with this
+ * product's secret and forwards it here (POST /api/webhooks/relay) with headers
+ * x-connect-signature / x-connect-product / x-connect-recipient-key. We verify the
+ * HMAC (see lib/relay.verifyRelaySignature) before acting on any event.
+ *
+ * Raw body for HMAC comes from the app-wide express.json({ verify }) in server.ts.
+ * See docs/RELAY-CONNECT-HUB-MIGRATION.md.
+ */
+
+import express, { type Router } from 'express';
+
+import { logger } from '../lib/logger';
+import { prisma } from '../lib/prisma';
+import { verifyRelaySignature } from '../lib/relay';
+import { PurchaseRepository } from '../repositories/implementations/PurchaseRepository';
+import type { IPurchaseReader, IPurchaseWriter } from '../repositories/IPurchaseRepository';
+
+const router = express.Router();
+const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:4301';
+
+function callbackUrl(): string {
+  return (
+    process.env.FIELDVIEW_WEBHOOK_CALLBACK_URL ||
+    `${API_BASE_URL.replace(/\/$/, '')}/api/webhooks/relay`
+  );
+}
+
+export interface RelayWebhookEvent {
+  type?: string;
+  data?: { object?: Record<string, unknown> };
+}
+
+export interface IRelayWebhookHandler {
+  handle(event: RelayWebhookEvent, ctx: { productKey?: string; recipientKey?: string }): Promise<void>;
+}
+
+/**
+ * Minimal handler: on a completed refund, mark the purchase refunded. Dispute and
+ * payment updates are acknowledged/logged — extend once the webhook is live and the
+ * exact forwarded event shapes are confirmed against the relay canary.
+ */
+export class RelayWebhookHandler implements IRelayWebhookHandler {
+  constructor(
+    private purchaseReader: IPurchaseReader,
+    private purchaseWriter: IPurchaseWriter,
+  ) {}
+
+  async handle(event: RelayWebhookEvent): Promise<void> {
+    if (event.type === 'refund.updated') {
+      const refund = event.data?.object?.refund as { payment_id?: string; status?: string } | undefined;
+      if (refund?.payment_id && refund.status === 'COMPLETED') {
+        const purchase = await this.purchaseReader.getByPaymentProviderId(refund.payment_id);
+        if (purchase) {
+          await this.purchaseWriter.update(purchase.id, { status: 'refunded', refundedAt: new Date() });
+        }
+      }
+    }
+    // 'dispute.created' / 'payment.updated' are acknowledged; handle when live.
+  }
+}
+
+let handlerInstance: IRelayWebhookHandler | null = null;
+
+function getHandler(): IRelayWebhookHandler {
+  if (!handlerInstance) {
+    const purchaseRepo = new PurchaseRepository(prisma);
+    handlerInstance = new RelayWebhookHandler(purchaseRepo, purchaseRepo);
+  }
+  return handlerInstance;
+}
+
+export function setRelayWebhookHandler(h: IRelayWebhookHandler): void {
+  handlerInstance = h;
+}
+
+/**
+ * POST /api/webhooks/relay
+ */
+router.post('/relay', (req, res, next) => {
+  void (async () => {
+    try {
+      const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
+      const bodyString = rawBody ? rawBody.toString('utf8') : JSON.stringify(req.body);
+      const signature = req.headers['x-connect-signature'] as string | undefined;
+
+      if (!verifyRelaySignature(signature, bodyString, callbackUrl())) {
+        return res.status(401).json({ error: { code: 'INVALID_SIGNATURE', message: 'Invalid relay signature' } });
+      }
+
+      const event = JSON.parse(bodyString) as RelayWebhookEvent;
+      const ctx = {
+        productKey: req.headers['x-connect-product'] as string | undefined,
+        recipientKey: req.headers['x-connect-recipient-key'] as string | undefined,
+      };
+      logger.info({ type: event.type, productKey: ctx.productKey, recipientKey: ctx.recipientKey }, 'Relay webhook received');
+      await getHandler().handle(event, ctx);
+
+      res.status(200).json({ received: true });
+    } catch (error) {
+      next(error);
+    }
+  })();
+});
+
+export function createRelayWebhookRouter(): Router {
+  return router;
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -60,6 +60,7 @@ import scoreboardRouter from './routes/scoreboard';
 import { createTestCleanupRouter } from './routes/test.cleanup';
 import { createTestStreamsRouter } from './routes/test.streams';
 import { createSquareWebhookRouter } from './routes/webhooks.square';
+import { createRelayWebhookRouter } from './routes/webhooks.relay';
 import { createTwilioWebhookRouter } from './routes/webhooks.twilio';
 import clipsRouter from './routes/clips.routes';
 import bookmarksRouter from './routes/bookmarks.routes';
@@ -163,6 +164,7 @@ app.use('/api/bookmarks', bookmarksRouter);
 app.use('/api/recordings', recordingsRouter);
 app.use('/api/webhooks', createTwilioWebhookRouter());
 app.use('/api/webhooks', createSquareWebhookRouter());
+app.use('/api/webhooks', createRelayWebhookRouter());
 
 // Test routes (POC/development only)
 const enableTestRoutes = process.env.ENABLE_TEST_ROUTES === '1' || process.env.NODE_ENV !== 'production';


### PR DESCRIPTION
Syncs Slice C.3 (relay inbound webhook, #94) to develop after a transient GitHub 504 dropped the original develop PR. Same verified commit already on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)