### PR TITLE
feat(payments): Slice E — Recipient Agreement + go-live config

### DIFF
--- a/apps/web/app/legal/recipient-agreement/page.tsx
+++ b/apps/web/app/legal/recipient-agreement/page.tsx
@@ -1,0 +1,69 @@
+export const metadata = {
+  title: 'Recipient (Payouts) Agreement — FieldView',
+};
+
+/**
+ * Static Recipient Agreement page (v1), linked from the owner payouts onboarding
+ * (/owners/payments). Text mirrors docs/legal/RECIPIENT-AGREEMENT-v1.md.
+ * DRAFT — pending attorney review before go-live.
+ */
+export default function RecipientAgreementPage() {
+  return (
+    <div className="min-h-screen bg-background">
+      <main className="container mx-auto max-w-3xl px-4 sm:px-6 py-8 sm:py-12 space-y-6">
+        <div className="rounded-lg bg-amber-50 border border-amber-200 p-3 text-amber-800 text-sm">
+          Draft — this agreement is pending legal review. Version <span className="font-mono">v1</span>.
+        </div>
+
+        <div>
+          <h1 className="text-2xl sm:text-3xl font-semibold">FieldView Recipient (Payouts) Agreement</h1>
+          <p className="text-sm text-muted-foreground mt-1">Effective version: v1</p>
+        </div>
+
+        <p className="text-sm text-muted-foreground">
+          By connecting your Square account through FieldView, you (&quot;Recipient&quot;) agree to the following:
+        </p>
+
+        <ol className="list-decimal pl-5 space-y-4 text-sm leading-relaxed">
+          <li>
+            <strong>You are the seller.</strong> Viewers&apos; payments for your streams settle directly into your
+            own Square merchant account. FieldView never takes possession of your funds.
+          </li>
+          <li>
+            <strong>Platform fee.</strong> FieldView retains a platform application fee (default 10%) on each
+            transaction, applied by Square at the time of charge. The remainder settles to your Square balance.
+            Square&apos;s own processing fees apply per your Square agreement.
+          </li>
+          <li>
+            <strong>Your Square account.</strong> You are responsible for maintaining your Square account in good
+            standing, for the accuracy of your business/location information, and for any taxes on your earnings.
+            Payouts to your bank follow Square&apos;s payout schedule.
+          </li>
+          <li>
+            <strong>Refunds &amp; disputes.</strong> Refunds (full or partial) may be issued for a transaction;
+            Square reverses the platform fee proportionally. You are responsible for chargebacks and disputes on
+            your merchant account per Square&apos;s terms.
+          </li>
+          <li>
+            <strong>Content &amp; conduct.</strong> You are responsible for the streams you sell and for complying
+            with applicable law and the rights of others (including broadcast/venue rights). FieldView may suspend
+            payouts or access for violations.
+          </li>
+          <li>
+            <strong>Termination.</strong> Either party may end this arrangement. You may disconnect Square at any
+            time; doing so stops new charges to your account through FieldView.
+          </li>
+          <li>
+            <strong>No warranty; limitation of liability.</strong> FieldView provides the platform &quot;as is.&quot;
+            To the extent permitted by law, FieldView is not liable for indirect or consequential damages arising
+            from the payments integration.
+          </li>
+        </ol>
+
+        <p className="text-sm text-muted-foreground">
+          Questions: <a href="mailto:support@fieldview.live" className="underline">support@fieldview.live</a>
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/docs/RELAY-CONNECT-HUB-MIGRATION.md
+++ b/docs/RELAY-CONNECT-HUB-MIGRATION.md
@@ -88,3 +88,27 @@ Charge accepts `note`, `reference_id` (use `purchaseId`), `statement_description
 ## 8. Verification (per slice)
 
 Relay canary + `test.squareup.noctusoft.com` console (catalog, card-on-file, charge, refund, subscription, webhook fanout) + FieldView e2e against a sandbox recipient, before enabling a real coach.
+
+## 9. Go-live env matrix (FieldView API — Railway)
+
+| Env var | Purpose | Default |
+|---|---|---|
+| `NOCTUSOFT_API_KEY` | Relay deploy key (`nsins_dk_…`); Bearer auth to the relay | — (required) |
+| `NOCTUSOFT_RELAY_SQUARE_BASE_URL` | Connect Hub base | `https://api.square.noctusoft.com` |
+| `NOCTUSOFT_PRODUCT_KEY` | Connect Hub product slug | `fieldview` |
+| `PAYMENTS_VIA_RELAY` | Route checkout/refunds through the relay | `false` (OFF) |
+| `RELAY_AGREEMENT_VERSION` | Recipient Agreement version to record | `v1` |
+| `FIELDVIEW_WEBHOOK_SECRET` | Verifies relay-forwarded webhooks (HMAC) | — (required for webhooks) |
+| `FIELDVIEW_WEBHOOK_CALLBACK_URL` | Exact URL the relay signs against | `${API_BASE_URL}/api/webhooks/relay` |
+
+On `ns` (relay): `connect_apps` for `fieldview` → `app_fee_bps=1000`, `agreement_version=v1`, `webhook_callback_url`, `post_connect_redirect=…/owners/dashboard?payments_connected=true`; set `NOCTUSOFT_SQUARE_WEBHOOK_SIGNATURE_KEY_{PROD,SANDBOX}` + the product's webhook signing secret; register the relay's Square webhook. The Recipient Agreement text (v1) must match: see `docs/legal/RECIPIENT-AGREEMENT-v1.md` (attorney review pending).
+
+## 10. Canary checklist (before flipping `PAYMENTS_VIA_RELAY=true` in prod)
+
+1. Provision `fieldview` on the relay; set the Railway env above (sandbox values first).
+2. Connect ONE sandbox coach via `/owners/payments` (agreement → OAuth → Location ID).
+3. Run a `$1` charge (viewer checkout) → confirm 90/10 split + entitlement.
+4. Issue an admin refund → confirm app-fee reversal + purchase status.
+5. Exercise the webhook (`refund.updated`) via `test.squareup.noctusoft.com` → confirm 200 + status update.
+6. Repeat on production values with a real coach before broad enablement.
+7. Only after this passes: schedule **Slice F** (delete Model A / remove the fallback).

--- a/docs/legal/RECIPIENT-AGREEMENT-v1.md
+++ b/docs/legal/RECIPIENT-AGREEMENT-v1.md
@@ -1,0 +1,39 @@
+# FieldView Recipient (Payouts) Agreement — v1
+
+> **DRAFT — pending attorney review.** This is a best-effort starting point for the
+> agreement a coach/owner accepts before connecting Square to receive payouts. It
+> MUST be reviewed and finalized by counsel before go-live. The version string here
+> (`v1`) must match `connect_apps.agreement_version` for the `fieldview` product on
+> the relay and `RELAY_AGREEMENT_VERSION` in the FieldView API.
+
+**Effective version:** v1
+
+By connecting your Square account through FieldView, you ("Recipient") agree to the following:
+
+1. **You are the seller.** Viewers' payments for your streams settle directly into
+   **your own Square merchant account**. FieldView never takes possession of your funds.
+
+2. **Platform fee.** FieldView retains a platform application fee (default **10%**) on
+   each transaction, applied by Square at the time of charge. The remainder settles to
+   your Square balance. Square's own processing fees apply per your Square agreement.
+
+3. **Your Square account.** You are responsible for maintaining your Square account in
+   good standing, for the accuracy of your business/location information, and for any
+   taxes on your earnings. Payouts to your bank follow Square's payout schedule.
+
+4. **Refunds & disputes.** Refunds (full or partial) may be issued for a transaction;
+   Square reverses the platform fee proportionally. You are responsible for chargebacks
+   and disputes on your merchant account per Square's terms.
+
+5. **Content & conduct.** You are responsible for the streams you sell and for
+   complying with applicable law and the rights of others (including broadcast/venue
+   rights). FieldView may suspend payouts or access for violations.
+
+6. **Termination.** Either party may end this arrangement. You may disconnect Square at
+   any time; doing so stops new charges to your account through FieldView.
+
+7. **No warranty; limitation of liability.** FieldView provides the platform "as is."
+   To the extent permitted by law, FieldView is not liable for indirect or
+   consequential damages arising from the payments integration.
+
+_Questions: support@fieldview.live_


### PR DESCRIPTION
**Slice E** — the Recipient Agreement (v1) + go-live config/canary docs. Last ungated slice.

- `docs/legal/RECIPIENT-AGREEMENT-v1.md` — best-effort payouts agreement (**DRAFT, attorney-review flagged**); must match `connect_apps.agreement_version`.
- `/legal/recipient-agreement` page (linked from `/owners/payments`).
- `RELAY-CONNECT-HUB-MIGRATION.md` — env matrix (`NOCTUSOFT_API_KEY`, `PAYMENTS_VIA_RELAY`, `FIELDVIEW_WEBHOOK_SECRET`, `RELAY_AGREEMENT_VERSION`, …) + canary checklist.

Verified: web **build ✅**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)