### PR TITLE
feat(env-chrome): loud dev/uat banner, invisible on prod

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -4,23 +4,38 @@ import './globals.css';
 import '@/styles/v2/tokens.css'; // v2 Design Tokens
 import { VersionDisplay } from '@/components/VersionDisplay';
 import { TrakletWidget } from '@/components/TrakletWidget';
+import { EnvChrome } from '@/lib/env-chrome/EnvChrome';
+import { badgeFor } from '@/lib/env-chrome/chrome';
+import { resolveServerEnv } from '@/lib/env-chrome/resolve';
+import { HOST_RULES } from '@/env-chrome.config';
 
-const inter = Inter({ 
+const inter = Inter({
   subsets: ['latin'],
   display: 'swap',
   variable: '--font-inter',
 });
 
-export const metadata: Metadata = {
-  title: 'FieldView.Live',
-  description: 'Monetization platform for youth sports live streaming',
-  manifest: '/manifest.json',
-  appleWebApp: {
-    capable: true,
-    statusBarStyle: 'default',
-    title: 'FieldView.Live',
-  },
-};
+const BASE_TITLE = 'FieldView.Live';
+const BASE_DESCRIPTION = 'Monetization platform for youth sports live streaming';
+
+export function generateMetadata(): Metadata {
+  const env = resolveServerEnv();
+  const badge = badgeFor(env);
+  const prefix = badge ? `[${badge.short}] ` : '';
+  return {
+    title: {
+      template: `${prefix}%s`,
+      default: `${prefix}${BASE_TITLE}`,
+    },
+    description: BASE_DESCRIPTION,
+    manifest: '/manifest.json',
+    appleWebApp: {
+      capable: true,
+      statusBarStyle: 'default',
+      title: BASE_TITLE,
+    },
+  };
+}
 
 export const viewport: Viewport = {
   width: 'device-width',
@@ -38,9 +53,11 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const env = resolveServerEnv();
   return (
     <html lang="en" className={inter.variable}>
       <body className={`${inter.className} min-h-screen`}>
+        <EnvChrome env={env} hostRules={HOST_RULES} />
         {children}
         <TrakletWidget />
         <VersionDisplay />

--- a/apps/web/env-chrome.config.ts
+++ b/apps/web/env-chrome.config.ts
@@ -1,0 +1,14 @@
+import type { HostRule } from '@/lib/env-chrome/chrome';
+
+/**
+ * FieldView.Live hostname → environment rules for the shared env-chrome
+ * pattern. See `/Users/admin/.claude/plans/lovely-bouncing-pelican.md` for
+ * the spec. UAT tier isn't provisioned yet — the rule is here so the day it
+ * lands, `uat.fieldview.live` will Just Work.
+ */
+export const HOST_RULES: readonly HostRule[] = [
+  [/^dev\.fieldview\.live$/i, 'dev'],
+  [/^uat\.fieldview\.live$/i, 'uat'],
+  [/^(www\.)?fieldview\.live$/i, 'production'],
+  [/^(localhost|127\.0\.0\.1|\[::1\])$/i, 'local'],
+];

--- a/apps/web/lib/env-chrome/EnvChrome.tsx
+++ b/apps/web/lib/env-chrome/EnvChrome.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect } from 'react';
+import { applyEnvChrome, envFromHost, type AppEnv, type HostRule } from './chrome';
+
+/**
+ * Mount once in `app/layout.tsx`. Renders no DOM itself — it applies the
+ * banner/title/favicon chrome via DOM mutation on mount.
+ *
+ * `env` is the server-authoritative value (from `resolveServerEnv()`). We also
+ * do an instant hostname guess before hydration for zero-flicker first paint,
+ * then reconcile if the server disagrees.
+ */
+export function EnvChrome({
+  env,
+  hostRules,
+}: {
+  env: AppEnv;
+  hostRules: readonly HostRule[];
+}) {
+  useEffect(() => {
+    const instant = envFromHost(location.hostname, hostRules);
+    applyEnvChrome(instant);
+    if (env !== instant) applyEnvChrome(env);
+  }, [env, hostRules]);
+
+  return null;
+}

--- a/apps/web/lib/env-chrome/chrome.test.ts
+++ b/apps/web/lib/env-chrome/chrome.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { badgeFor, envFromHost, faviconDataUri } from './chrome';
+import { HOST_RULES } from '@/env-chrome.config';
+
+describe('envFromHost — FieldView.Live hostname rules', () => {
+  it('maps the friendly domains to their environment', () => {
+    expect(envFromHost('dev.fieldview.live', HOST_RULES)).toBe('dev');
+    expect(envFromHost('uat.fieldview.live', HOST_RULES)).toBe('uat');
+    expect(envFromHost('fieldview.live', HOST_RULES)).toBe('production');
+    expect(envFromHost('www.fieldview.live', HOST_RULES)).toBe('production');
+  });
+
+  it('treats localhost as local and anything else as unknown', () => {
+    expect(envFromHost('localhost', HOST_RULES)).toBe('local');
+    expect(envFromHost('127.0.0.1', HOST_RULES)).toBe('local');
+    expect(envFromHost('some-random-host.example.com', HOST_RULES)).toBe('unknown');
+  });
+
+  it('never mislabels the bare prod domain as a sub-env (no false banner on prod)', () => {
+    expect(envFromHost('fieldview.live', HOST_RULES)).not.toBe('dev');
+    expect(envFromHost('fieldview.live', HOST_RULES)).not.toBe('uat');
+    expect(envFromHost('www.fieldview.live', HOST_RULES)).not.toBe('dev');
+    expect(envFromHost('www.fieldview.live', HOST_RULES)).not.toBe('uat');
+  });
+});
+
+describe('badgeFor', () => {
+  it('returns null for production and unknown (clean, no chrome)', () => {
+    expect(badgeFor('production')).toBeNull();
+    expect(badgeFor('unknown')).toBeNull();
+  });
+
+  it('returns a warning badge for non-prod envs with the standard palette', () => {
+    expect(badgeFor('uat')).toMatchObject({ short: 'UAT', color: '#b45309', letter: 'U' });
+    expect(badgeFor('dev')).toMatchObject({ short: 'DEV', color: '#4338ca', letter: 'D' });
+    expect(badgeFor('local')).toMatchObject({ short: 'LOCAL', color: '#334155', letter: 'L' });
+    expect(badgeFor('uat')?.label).toMatch(/not production/i);
+  });
+});
+
+describe('faviconDataUri', () => {
+  it('produces an inline SVG data URI carrying the colour and letter', () => {
+    const uri = faviconDataUri('#b45309', 'U');
+    expect(uri.startsWith('data:image/svg+xml,')).toBe(true);
+    const svg = decodeURIComponent(uri.slice('data:image/svg+xml,'.length));
+    expect(svg).toContain('#b45309');
+    expect(svg).toContain('>U<');
+  });
+});

--- a/apps/web/lib/env-chrome/chrome.ts
+++ b/apps/web/lib/env-chrome/chrome.ts
@@ -1,0 +1,89 @@
+/**
+ * Environment delineation chrome — isomorphic pieces (badge table, hostname
+ * mapper, favicon SVG generator, DOM applier). Ports the CaptionFlow pattern
+ * with one change: `envFromHost` takes `hostRules` as a parameter so each
+ * project can pass its own `HOST_RULES` without forking this file.
+ *
+ * Standard defined at `/Users/admin/.claude/plans/lovely-bouncing-pelican.md`.
+ * Any change to the visual mapping here must match every other project's copy.
+ */
+
+export type AppEnv = 'dev' | 'uat' | 'production' | 'local' | 'unknown';
+
+export type HostRule = readonly [RegExp, AppEnv];
+
+export function envFromHost(host: string, hostRules: readonly HostRule[]): AppEnv {
+  for (const [re, env] of hostRules) if (re.test(host)) return env;
+  return 'unknown';
+}
+
+export type Badge = { label: string; short: string; color: string; letter: string };
+
+export const BADGES: Record<Exclude<AppEnv, 'production' | 'unknown'>, Badge> = {
+  uat: { label: 'UAT · Test environment — not production', short: 'UAT', color: '#b45309', letter: 'U' },
+  dev: { label: 'Development', short: 'DEV', color: '#4338ca', letter: 'D' },
+  local: { label: 'Local dev', short: 'LOCAL', color: '#334155', letter: 'L' },
+};
+
+export function badgeFor(env: AppEnv): Badge | null {
+  return env === 'production' || env === 'unknown' ? null : BADGES[env];
+}
+
+export function faviconDataUri(color: string, letter: string): string {
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">` +
+    `<rect width="32" height="32" rx="7" fill="${color}"/>` +
+    `<text x="16" y="23" font-family="ui-sans-serif,system-ui,sans-serif" font-size="20" ` +
+    `font-weight="700" text-anchor="middle" fill="#fff">${letter}</text></svg>`;
+  return 'data:image/svg+xml,' + encodeURIComponent(svg);
+}
+
+let baseTitle: string | null = null;
+let baseFavicon: string | null = null;
+
+function faviconLink(): HTMLLinkElement {
+  let link = document.querySelector<HTMLLinkElement>('link[rel~="icon"]');
+  if (!link) {
+    link = document.createElement('link');
+    link.rel = 'icon';
+    document.head.appendChild(link);
+  }
+  return link;
+}
+
+/** Apply (or clear, for production) the banner + title prefix + favicon tint. */
+export function applyEnvChrome(env: AppEnv): void {
+  if (baseTitle === null) baseTitle = document.title.replace(/^\[[A-Z]+\]\s+/, '');
+  const link = faviconLink();
+  if (baseFavicon === null) baseFavicon = link.getAttribute('href') || '/favicon.ico';
+
+  const badge = badgeFor(env);
+  const existing = document.getElementById('env-banner');
+
+  if (!badge) {
+    existing?.remove();
+    document.title = baseTitle;
+    link.setAttribute('href', baseFavicon);
+    return;
+  }
+
+  const banner = existing ?? document.createElement('div');
+  banner.id = 'env-banner';
+  banner.setAttribute('role', 'status');
+  banner.textContent = badge.label;
+  banner.style.cssText = [
+    `background:${badge.color}`,
+    'color:#fff',
+    'font:700 12px/1.5 ui-sans-serif,system-ui,-apple-system,sans-serif',
+    'letter-spacing:.06em',
+    'text-transform:uppercase',
+    'text-align:center',
+    'padding:5px 12px',
+    'width:100%',
+    'box-sizing:border-box',
+  ].join(';');
+  if (!existing) document.body.insertBefore(banner, document.body.firstChild);
+
+  document.title = `[${badge.short}] ${baseTitle}`;
+  link.setAttribute('href', faviconDataUri(badge.color, badge.letter));
+}

--- a/apps/web/lib/env-chrome/resolve.test.ts
+++ b/apps/web/lib/env-chrome/resolve.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { normalizeEnv, resolveServerEnv } from './resolve';
+
+describe('normalizeEnv', () => {
+  it('normalizes the canonical values', () => {
+    expect(normalizeEnv('production')).toBe('production');
+    expect(normalizeEnv('uat')).toBe('uat');
+    expect(normalizeEnv('dev')).toBe('dev');
+    expect(normalizeEnv('local')).toBe('local');
+  });
+
+  it('maps synonyms', () => {
+    expect(normalizeEnv('prod')).toBe('production');
+    expect(normalizeEnv('staging')).toBe('uat');
+    expect(normalizeEnv('qa')).toBe('uat');
+    expect(normalizeEnv('preview')).toBe('uat');
+    expect(normalizeEnv('development')).toBe('dev');
+    expect(normalizeEnv('test')).toBe('local');
+  });
+
+  it('is case- and whitespace-insensitive', () => {
+    expect(normalizeEnv('  UAT  ')).toBe('uat');
+    expect(normalizeEnv('Production')).toBe('production');
+  });
+
+  it('returns "unknown" for empty / null / gibberish', () => {
+    expect(normalizeEnv(undefined)).toBe('unknown');
+    expect(normalizeEnv(null)).toBe('unknown');
+    expect(normalizeEnv('')).toBe('unknown');
+    expect(normalizeEnv('   ')).toBe('unknown');
+    expect(normalizeEnv('nonsense')).toBe('unknown');
+  });
+});
+
+describe('resolveServerEnv — env-var priority', () => {
+  beforeEach(() => {
+    vi.stubEnv('APP_ENV', '');
+    vi.stubEnv('VERCEL_ENV', '');
+    vi.stubEnv('RAILWAY_ENVIRONMENT', '');
+    vi.stubEnv('NODE_ENV', '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('APP_ENV wins over everything', () => {
+    vi.stubEnv('APP_ENV', 'uat');
+    vi.stubEnv('VERCEL_ENV', 'production');
+    vi.stubEnv('NODE_ENV', 'production');
+    expect(resolveServerEnv()).toBe('uat');
+  });
+
+  it('falls back to VERCEL_ENV when APP_ENV is unset (preview → uat)', () => {
+    vi.stubEnv('VERCEL_ENV', 'preview');
+    expect(resolveServerEnv()).toBe('uat');
+  });
+
+  it('falls back to RAILWAY_ENVIRONMENT', () => {
+    vi.stubEnv('RAILWAY_ENVIRONMENT', 'dev');
+    expect(resolveServerEnv()).toBe('dev');
+  });
+
+  it('falls back to NODE_ENV=production', () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    expect(resolveServerEnv()).toBe('production');
+  });
+
+  it('defaults to "local" when no env var is set', () => {
+    expect(resolveServerEnv()).toBe('local');
+  });
+
+  it('coerces "unknown" (unrecognized synonym) to "local" so we never render a false banner', () => {
+    vi.stubEnv('APP_ENV', 'nonsense-value');
+    expect(resolveServerEnv()).toBe('local');
+  });
+});

--- a/apps/web/lib/env-chrome/resolve.ts
+++ b/apps/web/lib/env-chrome/resolve.ts
@@ -1,0 +1,38 @@
+import type { AppEnv } from './chrome';
+
+const SYNONYMS: Record<string, AppEnv> = {
+  production: 'production',
+  prod: 'production',
+  uat: 'uat',
+  staging: 'uat',
+  qa: 'uat',
+  preview: 'uat',
+  dev: 'dev',
+  development: 'dev',
+  local: 'local',
+  test: 'local',
+  'development-local': 'local',
+};
+
+export function normalizeEnv(raw: string | undefined | null): AppEnv {
+  if (raw === undefined || raw === null) return 'unknown';
+  const s = String(raw).trim().toLowerCase();
+  if (!s) return 'unknown';
+  return SYNONYMS[s] ?? 'unknown';
+}
+
+/**
+ * Server-side env detection. Reads `process.env` in priority order:
+ * APP_ENV → VERCEL_ENV → RAILWAY_ENVIRONMENT → NODE_ENV → 'local'.
+ * Never returns 'unknown' — 'unknown' falls back to 'local'.
+ */
+export function resolveServerEnv(): AppEnv {
+  const raw =
+    process.env.APP_ENV ||
+    process.env.VERCEL_ENV ||
+    process.env.RAILWAY_ENVIRONMENT ||
+    process.env.NODE_ENV ||
+    'local';
+  const normalized = normalizeEnv(raw);
+  return normalized === 'unknown' ? 'local' : normalized;
+}


### PR DESCRIPTION
## Summary

Ports the CaptionFlow "env chrome" pattern to \`apps/web\`. Once \`APP_ENV\` is set per deployment, any deployed instance shows:

- **dev.fieldview.live** → indigo bar reading \`Development\`, browser tab reads \`[DEV] FieldView.Live\`, favicon is a blue \`D\`
- **uat.fieldview.live** → amber bar, \`[UAT]\` tab, amber \`U\` favicon (rule pre-provisioned — the day the uat tier lands, it Just Works)
- **fieldview.live / www.fieldview.live** → **completely clean.** No banner, no tab prefix, real favicon.

Server-authoritative via \`APP_ENV\` (with fallbacks \`VERCEL_ENV\`, \`RAILWAY_ENVIRONMENT\`, \`NODE_ENV\`). Instant hostname-based first paint so no flash before hydration.

## Files

- \`apps/web/lib/env-chrome/chrome.ts\` — badge table, favicon SVG, DOM applier
- \`apps/web/lib/env-chrome/resolve.ts\` — server-side env-var priority resolver
- \`apps/web/lib/env-chrome/EnvChrome.tsx\` — thin client component
- \`apps/web/env-chrome.config.ts\` — the only project-specific piece: \`HOST_RULES\`
- \`apps/web/lib/env-chrome/{chrome,resolve}.test.ts\` — 16 vitest cases (16/16 passing)
- \`apps/web/app/layout.tsx\` — static \`metadata\` → \`generateMetadata()\` for server-side title prefix; mount \`<EnvChrome/>\` first inside \`<body>\`

## Set APP_ENV per deployment

| Deployment | Set |
|---|---|
| dev.fieldview.live | \`APP_ENV=dev\` |
| uat.fieldview.live (when the tier lands) | \`APP_ENV=uat\` |
| fieldview.live / www.fieldview.live | \`APP_ENV=production\` — or leave unset; Railway's \`RAILWAY_ENVIRONMENT=production\` takes over |

Fits the project's Railway deploy target (deploy key auth already set — see \`.cursorrules\`).

## Standard palette (identical across all Noctusoft/YOLO/StuPath projects)

| Env | Color | Prefix | Favicon letter |
|---|---|---|---|
| dev | indigo \`#4338ca\` | \`[DEV]\` | D |
| uat | amber \`#b45309\` | \`[UAT]\` | U |
| local | slate \`#334155\` | \`[LOCAL]\` | L |
| production | — | — | — |

## Test plan

- [x] \`vitest run lib/env-chrome/\` — 16/16 passing
- [x] \`tsc --noEmit\` — clean
- [ ] After merge + dev deploy on Railway: navigate to \`dev.fieldview.live\` → indigo bar + \`[DEV]\` tab + blue D favicon
- [ ] On \`fieldview.live\` production: **nothing** — no bar, no prefix, real favicon

## Standard spec

Full spec at \`/Users/admin/.claude/plans/lovely-bouncing-pelican.md\`. Sibling PRs opened in this session:

- BlessBox rvegajr/blessbox#59
- EscalatingReminders YOLOVibeCode/escalating-reminders#2
- RubriqFlow rvegajr/rubriq-flow#132
- (Ember Lead PR to follow immediately after this one)

Source pattern: \`CaptionFlow src/web/env-chrome.ts\` (Vite/SPA vanilla-TS version — this is the Next.js App Router adaptation).