### PR TITLE
Phase 0: migrate-on-deploy + DEV seed + UAT clone/anonymize (three-env groundwork)

### DIFF
--- a/apps/api/railway.toml
+++ b/apps/api/railway.toml
@@ -3,8 +3,9 @@ builder = "NIXPACKS"
 buildCommand = "cd ../.. && pnpm install --frozen-lockfile && pnpm --filter @fieldview/data-model exec prisma generate --schema=./prisma/schema.prisma && pnpm --filter @fieldview/data-model build && pnpm --filter api build"
 
 [deploy]
-# Temporarily skip migrations to get server running
-startCommand = "node dist/server.js"
+# Apply any pending Prisma migrations, then start. `migrate deploy` is idempotent
+# (only applies un-run migrations) and runs against this environment's DATABASE_URL.
+startCommand = "pnpm --filter @fieldview/data-model db:deploy && node dist/server.js"
 healthcheckPath = "/health"
 healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"

--- a/packages/data-model/package.json
+++ b/packages/data-model/package.json
@@ -14,6 +14,7 @@
     "lint:fix": "eslint src --ext .ts --fix",
     "db:generate": "pnpm exec prisma generate --schema=./prisma/schema.prisma",
     "db:migrate": "pnpm exec prisma migrate dev --schema=./prisma/schema.prisma",
+    "db:deploy": "pnpm exec prisma migrate deploy --schema=./prisma/schema.prisma",
     "db:studio": "pnpm exec prisma studio --schema=./prisma/schema.prisma"
   },
   "dependencies": {

--- a/scripts/clone-prod-to-uat.ts
+++ b/scripts/clone-prod-to-uat.ts
@@ -1,0 +1,150 @@
+/**
+ * Clone PRODUCTION data into UAT, then anonymize PII and repoint payments to sandbox.
+ *
+ * Two stages:
+ *   1. Structural clone (opt-in, RUN_STRUCTURAL_CLONE=1): pg_dump PROD_DATABASE_URL | psql DATABASE_URL.
+ *      Requires the postgres client tools (pg_dump/psql) and BOTH public connection strings.
+ *      Run this from an operator machine or a Railway one-off that has pg tools installed.
+ *   2. Anonymize (always): Prisma updateMany over PII/secret columns + delete ephemeral token rows.
+ *
+ * Payments: every prod recipient key / Square token is invalid against the UAT sandbox relay
+ * product, so we NULL them. Reconnect a sandbox coach via /owners/payments in UAT afterwards.
+ *
+ * SAFETY (all enforced):
+ *   - Refuses unless APP_ENV=uat (never runs against prod/dev by accident).
+ *   - Refuses if DATABASE_URL === PROD_DATABASE_URL.
+ *   - Requires CONFIRM_CLONE=uat to proceed.
+ *
+ * Usage:
+ *   APP_ENV=uat CONFIRM_CLONE=uat \
+ *   PROD_DATABASE_URL="postgresql://…prod…" DATABASE_URL="postgresql://…uat…" \
+ *   RUN_STRUCTURAL_CLONE=1 UAT_ADMIN_PASSWORD="…" UAT_OWNER_PASSWORD="…" \
+ *   pnpm exec tsx scripts/clone-prod-to-uat.ts
+ */
+
+import { execFileSync } from 'node:child_process';
+
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+const APP_ENV = (process.env.APP_ENV || '').toLowerCase();
+const TARGET = process.env.DATABASE_URL || '';
+const SOURCE = process.env.PROD_DATABASE_URL || '';
+
+function guard() {
+  if (APP_ENV !== 'uat') throw new Error(`Refusing: APP_ENV must be "uat" (got "${APP_ENV || 'unset'}").`);
+  if (process.env.CONFIRM_CLONE !== 'uat') throw new Error('Refusing: set CONFIRM_CLONE=uat to proceed.');
+  if (!TARGET) throw new Error('DATABASE_URL (UAT target) is required.');
+  if (SOURCE && SOURCE === TARGET) throw new Error('Refusing: PROD_DATABASE_URL === DATABASE_URL (would clone onto itself).');
+}
+
+function structuralClone() {
+  if (process.env.RUN_STRUCTURAL_CLONE !== '1') {
+    console.log('↷ Skipping structural clone (set RUN_STRUCTURAL_CLONE=1 to enable). Anonymizing existing UAT data.');
+    return;
+  }
+  if (!SOURCE) throw new Error('RUN_STRUCTURAL_CLONE=1 requires PROD_DATABASE_URL.');
+  console.log('⧉ Structural clone: pg_dump PROD → psql UAT (this DROPS and recreates the public schema on UAT)...');
+  // Reset target schema, then stream a data+schema dump. --no-owner/--no-acl for cross-instance restore.
+  execFileSync('psql', [TARGET, '-v', 'ON_ERROR_STOP=1', '-c', 'DROP SCHEMA public CASCADE; CREATE SCHEMA public;'], { stdio: 'inherit' });
+  const dump = execFileSync('pg_dump', ['--no-owner', '--no-acl', '--format=plain', SOURCE], { maxBuffer: 1024 * 1024 * 1024 });
+  execFileSync('psql', [TARGET, '-v', 'ON_ERROR_STOP=1'], { input: dump, stdio: ['pipe', 'inherit', 'inherit'] });
+  console.log('✔ Structural clone complete.');
+}
+
+async function anonymize() {
+  const prisma = new PrismaClient();
+  try {
+    const uatOwnerHash = await bcrypt.hash(process.env.UAT_OWNER_PASSWORD || 'uatowner123', 10);
+    const uatAdminHash = await bcrypt.hash(process.env.UAT_ADMIN_PASSWORD || 'uatadmin123', 10);
+
+    console.log('🔒 Anonymizing PII + repointing payments to sandbox...');
+
+    // --- Owners: mask identity, NULL all Square/relay payment state (invalid vs sandbox) ---
+    const owners = await prisma.ownerAccount.findMany({ select: { id: true } });
+    for (const { id } of owners) {
+      await prisma.ownerAccount.update({
+        where: { id },
+        data: {
+          name: `UAT Owner ${id.slice(0, 8)}`,
+          contactEmail: `owner+${id.slice(0, 8)}@uat.fieldview.live`,
+          payoutProviderRef: null,
+          squareAccessTokenEncrypted: null,
+          squareRefreshTokenEncrypted: null,
+          squareTokenExpiresAt: null,
+          squareLocationId: null,
+          relayRecipientKey: null,
+          paymentsConnectedAt: null,
+          agreementAcceptedVersion: null,
+        },
+      });
+    }
+    console.log(`  owners anonymized: ${owners.length}`);
+
+    // --- Owner users: mask email, reset password, clear MFA ---
+    const ownerUsers = await prisma.ownerUser.findMany({ select: { id: true } });
+    for (const { id } of ownerUsers) {
+      await prisma.ownerUser.update({
+        where: { id },
+        data: { email: `owneruser+${id.slice(0, 8)}@uat.fieldview.live`, passwordHash: uatOwnerHash, mfaSecret: null },
+      });
+    }
+    console.log(`  owner users anonymized: ${ownerUsers.length}`);
+
+    // --- Admins: mask, reset password, clear MFA ---
+    const admins = await prisma.adminAccount.findMany({ select: { id: true, role: true } });
+    for (const a of admins) {
+      await prisma.adminAccount.update({
+        where: { id: a.id },
+        data: { email: `admin+${a.id.slice(0, 8)}@uat.fieldview.live`, passwordHash: uatAdminHash, mfaSecret: null, mfaEnabled: false },
+      });
+    }
+    console.log(`  admins anonymized: ${admins.length} (a known UAT super_admin is re-seeded by seed-dev if needed)`);
+
+    // --- Viewer identities: mask contact info, clear tokens ---
+    const viewers = await prisma.viewerIdentity.findMany({ select: { id: true } });
+    for (const { id } of viewers) {
+      await prisma.viewerIdentity.update({
+        where: { id },
+        data: {
+          email: `viewer+${id.slice(0, 8)}@uat.fieldview.live`,
+          phoneE164: null,
+          firstName: 'UAT',
+          lastName: `Viewer ${id.slice(0, 6)}`,
+        },
+      });
+    }
+    console.log(`  viewers anonymized: ${viewers.length}`);
+
+    // --- Payment identifiers that reference prod Square (unusable in sandbox) ---
+    await prisma.viewerSquareCustomer.deleteMany({});
+    await prisma.purchase.updateMany({ data: { lastAccessedIp: null } });
+    await prisma.payout.updateMany({ data: { payoutProviderRef: null } });
+
+    // --- Veo credentials ---
+    await prisma.veoIntegration.updateMany({ data: { veoEmail: null, veoPasswordEncrypted: null } });
+
+    // --- Ephemeral token/secret tables: delete outright (they regenerate) ---
+    await prisma.emailVerificationToken.deleteMany({});
+    await prisma.passwordResetToken.deleteMany({});
+    await prisma.viewerRefreshToken.deleteMany({});
+    await prisma.sMSMessage.deleteMany({});
+    await prisma.earlyAccessSignup.deleteMany({});
+    console.log('  cleared ephemeral token/secret tables (email/password/refresh tokens, SMS, early-access signups)');
+
+    console.log('\n✅ Anonymize complete. Reconnect a sandbox coach via /owners/payments in UAT.');
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+async function main() {
+  guard();
+  structuralClone();
+  await anonymize();
+}
+
+main().catch((e) => {
+  console.error('❌ clone-prod-to-uat failed:', e instanceof Error ? e.message : e);
+  process.exit(1);
+});

--- a/scripts/railway-start.sh
+++ b/scripts/railway-start.sh
@@ -16,7 +16,9 @@ fi
 
 case "${target}" in
   api)
-    echo "Starting API server (migrations already applied)..."
+    echo "Applying pending Prisma migrations (idempotent)..."
+    pnpm --filter @fieldview/data-model db:deploy
+    echo "Starting API server..."
     exec pnpm --filter api start
     ;;
   web)

--- a/scripts/seed-dev.ts
+++ b/scripts/seed-dev.ts
@@ -1,0 +1,135 @@
+/**
+ * DEV / non-prod seed.
+ *
+ * Creates a minimal, idempotent dataset for the DEVELOPMENT (and UAT-fresh) tiers:
+ *   - super_admin  (admin@fieldview.live)               — password from ADMIN_PASSWORD (default dev value)
+ *   - a test owner (dev-owner@fieldview.live)           — ready to connect Square SANDBOX via /owners/payments
+ *   - a free demo stream + a paywalled demo stream       — for the relay sandbox charge canary
+ *
+ * Payments note: the owner is created WITHOUT a relayRecipientKey on purpose — a real
+ * sandbox coach connection happens through the UI (/owners/payments → agreement → Square
+ * OAuth), which is what sets relayRecipientKey + paymentsConnectedAt. A fabricated key
+ * would have no Square tokens behind it and could not charge.
+ *
+ * Safety: refuses to run when APP_ENV=production. Idempotent (upserts by email/slug).
+ *
+ * Usage: DATABASE_URL="postgresql://..." ADMIN_PASSWORD="..." pnpm exec tsx scripts/seed-dev.ts
+ */
+
+import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcryptjs';
+
+const prisma = new PrismaClient();
+
+const APP_ENV = (process.env.APP_ENV || '').toLowerCase();
+const ADMIN_EMAIL = 'admin@fieldview.live';
+const OWNER_EMAIL = 'dev-owner@fieldview.live';
+const DEV_ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'devadmin123';
+const DEV_OWNER_PASSWORD = process.env.DEV_OWNER_PASSWORD || 'devowner123';
+const DEMO_HLS_URL = 'https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8';
+
+async function ensureSuperAdmin() {
+  const passwordHash = await bcrypt.hash(DEV_ADMIN_PASSWORD, 10);
+  await prisma.adminAccount.upsert({
+    where: { email: ADMIN_EMAIL },
+    update: { passwordHash, status: 'active' },
+    create: {
+      email: ADMIN_EMAIL,
+      passwordHash,
+      role: 'super_admin',
+      status: 'active',
+      mfaEnabled: false,
+    },
+  });
+  console.log(`  super_admin ready: ${ADMIN_EMAIL}`);
+}
+
+async function ensureOwner(): Promise<string> {
+  const existing = await prisma.ownerAccount.findFirst({ where: { contactEmail: OWNER_EMAIL } });
+  const account =
+    existing ??
+    (await prisma.ownerAccount.create({
+      data: {
+        type: 'owner',
+        name: 'Dev Test Coach',
+        status: 'active',
+        contactEmail: OWNER_EMAIL,
+        freeGamesUsed: 0,
+        subscriptionTier: null,
+        // relayRecipientKey intentionally null — connect Square sandbox via /owners/payments.
+      },
+    }));
+
+  const ownerPasswordHash = await bcrypt.hash(DEV_OWNER_PASSWORD, 10);
+  const user = await prisma.ownerUser.findFirst({ where: { email: OWNER_EMAIL } });
+  if (user) {
+    await prisma.ownerUser.update({ where: { id: user.id }, data: { passwordHash: ownerPasswordHash, status: 'active' } });
+  } else {
+    await prisma.ownerUser.create({
+      data: {
+        ownerAccountId: account.id,
+        email: OWNER_EMAIL,
+        passwordHash: ownerPasswordHash,
+        role: 'owner_admin',
+        status: 'active',
+      },
+    });
+  }
+  console.log(`  owner ready: ${OWNER_EMAIL} (account ${account.id})`);
+  return account.id;
+}
+
+async function ensureStreams(ownerAccountId: string) {
+  const adminPassword = await bcrypt.hash('admin123', 10);
+  const streams = [
+    { slug: 'dev-free-stream', title: 'Dev Free Stream', paywallEnabled: false, priceInCents: 0 },
+    { slug: 'dev-paid-stream', title: 'Dev Paid Stream ($1.00 sandbox)', paywallEnabled: true, priceInCents: 100 },
+  ];
+  for (const s of streams) {
+    const existing = await prisma.directStream.findUnique({ where: { slug: s.slug } });
+    const data = {
+      title: s.title,
+      ownerAccountId,
+      streamUrl: DEMO_HLS_URL,
+      paywallEnabled: s.paywallEnabled,
+      priceInCents: s.priceInCents,
+      adminPassword,
+      chatEnabled: true,
+      scoreboardEnabled: true,
+      allowViewerScoreEdit: false,
+      allowViewerNameEdit: false,
+      allowAnonymousView: !s.paywallEnabled,
+      requireEmailVerification: true,
+      listed: true,
+      status: 'active',
+    };
+    if (existing) {
+      await prisma.directStream.update({ where: { slug: s.slug }, data });
+    } else {
+      await prisma.directStream.create({ data: { slug: s.slug, ...data } });
+    }
+    console.log(`  stream ready: /direct/${s.slug} (${s.paywallEnabled ? `$${(s.priceInCents / 100).toFixed(2)}` : 'free'})`);
+  }
+}
+
+async function main() {
+  if (APP_ENV === 'production') {
+    console.error('Refusing to seed: APP_ENV=production. This script is for DEV/UAT only.');
+    process.exit(1);
+  }
+  console.log(`🌱 Seeding DEV data (APP_ENV=${APP_ENV || 'unset'})...`);
+  await ensureSuperAdmin();
+  const ownerAccountId = await ensureOwner();
+  await ensureStreams(ownerAccountId);
+  console.log('\n✅ DEV seed complete.');
+  console.log(`   admin login: ${ADMIN_EMAIL} / ${DEV_ADMIN_PASSWORD}`);
+  console.log(`   owner login: ${OWNER_EMAIL} / ${DEV_OWNER_PASSWORD}`);
+  console.log('   → connect Square SANDBOX at /owners/payments to arm the payment canary.');
+}
+
+main()
+  .catch((e) => {
+    console.error('❌ Seed error:', e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
Groundwork for the **DEV → UAT → PROD** environment rollout (plan approved separately). Repo-only changes; Railway/relay/DNS config follows in later phases.

## What's here
- **Migrate-on-deploy** — new `@fieldview/data-model` `db:deploy` (= `prisma migrate deploy`), run before the API boots in both the primary path (`apps/api/railway.toml` `startCommand`) and the fallback (`scripts/railway-start.sh`). Removes the "temporarily skip migrations" hack.
  - **Side benefit:** self-heals the current prod `VeoIntegration` P2021 drift on the next `main` deploy, and guarantees every env is migrated.
- **`scripts/seed-dev.ts`** — idempotent DEV seed: `super_admin`, a test owner (ready to connect Square **sandbox** via `/owners/payments`), and free + `$1` paywalled demo streams. Refuses on `APP_ENV=production`.
- **`scripts/clone-prod-to-uat.ts`** — guarded prod→UAT structural clone (opt-in `pg_dump | psql`) + Prisma-based PII anonymizer. NULLs **all** Square/relay payment state (prod recipient keys/tokens are invalid against the UAT sandbox relay product). Refuses unless `APP_ENV=uat` **and** `CONFIRM_CLONE=uat`.

## Notes
- `migrate deploy` is idempotent (applies only un-run migrations) and runs against each env's own `DATABASE_URL`.
- APP_URL default normalization intentionally **deferred** — `APP_URL` is set explicitly in all three envs, so the inconsistent code defaults never fire; a helper refactor would be churn.
- Guards verified: both scripts refuse before any DB connection when run in the wrong env.

## Adjacent (separate follow-up, not in this PR)
Committed live-looking secrets found in `.env.example`, `apps/api/.env.production`, and a `gho_` token in `apps/web/.env.local` — recommend rotating + scrubbing from history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)