### PR TITLE
fix(env-chrome): RSC serialization — don't pass RegExp rules to client

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,7 +7,6 @@ import { TrakletWidget } from '@/components/TrakletWidget';
 import { EnvChrome } from '@/lib/env-chrome/EnvChrome';
 import { badgeFor } from '@/lib/env-chrome/chrome';
 import { resolveServerEnv } from '@/lib/env-chrome/resolve';
-import { HOST_RULES } from '@/env-chrome.config';
 
 const inter = Inter({
   subsets: ['latin'],
@@ -57,7 +56,7 @@ export default function RootLayout({
   return (
     <html lang="en" className={inter.variable}>
       <body className={`${inter.className} min-h-screen`}>
-        <EnvChrome env={env} hostRules={HOST_RULES} />
+        <EnvChrome env={env} />
         {children}
         <TrakletWidget />
         <VersionDisplay />

--- a/apps/web/lib/env-chrome/EnvChrome.tsx
+++ b/apps/web/lib/env-chrome/EnvChrome.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect } from 'react';
-import { applyEnvChrome, envFromHost, type AppEnv, type HostRule } from './chrome';
+import { HOST_RULES } from '@/env-chrome.config';
+import { applyEnvChrome, envFromHost, type AppEnv } from './chrome';
 
 /**
  * Mount once in `app/layout.tsx`. Renders no DOM itself — it applies the
@@ -9,20 +10,16 @@ import { applyEnvChrome, envFromHost, type AppEnv, type HostRule } from './chrom
  *
  * `env` is the server-authoritative value (from `resolveServerEnv()`). We also
  * do an instant hostname guess before hydration for zero-flicker first paint,
- * then reconcile if the server disagrees.
+ * then reconcile if the server disagrees. `HOST_RULES` is imported directly
+ * here (client side) — it contains `RegExp`s, which can't be serialized across
+ * the Server→Client boundary, so it must NOT be passed as a prop.
  */
-export function EnvChrome({
-  env,
-  hostRules,
-}: {
-  env: AppEnv;
-  hostRules: readonly HostRule[];
-}) {
+export function EnvChrome({ env }: { env: AppEnv }) {
   useEffect(() => {
-    const instant = envFromHost(location.hostname, hostRules);
+    const instant = envFromHost(location.hostname, HOST_RULES);
     applyEnvChrome(instant);
     if (env !== instant) applyEnvChrome(env);
-  }, [env, hostRules]);
+  }, [env]);
 
   return null;
 }


### PR DESCRIPTION
DEV web build failed static generation ("Only plain objects can be passed to Client Components") because `layout.tsx` passed `HOST_RULES` (RegExps) into the `EnvChrome` client component. Now EnvChrome imports `HOST_RULES` directly; layout passes only the `env` string. Verified locally: `pnpm --filter web build` exits 0, 43/43 pages generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)