### PR TITLE
fix(scripts): mask (not null) Veo creds in clone-prod-to-uat

### DIFF
--- a/scripts/clone-prod-to-uat.ts
+++ b/scripts/clone-prod-to-uat.ts
@@ -121,8 +121,8 @@ async function anonymize() {
     await prisma.purchase.updateMany({ data: { lastAccessedIp: null } });
     await prisma.payout.updateMany({ data: { payoutProviderRef: null } });
 
-    // --- Veo credentials ---
-    await prisma.veoIntegration.updateMany({ data: { veoEmail: null, veoPasswordEncrypted: null } });
+    // --- Veo credentials (both columns are NON-null; mask rather than null) ---
+    await prisma.veoIntegration.updateMany({ data: { veoEmail: 'veo-disabled@uat.invalid', veoPasswordEncrypted: '' } });
 
     // --- Ephemeral token/secret tables: delete outright (they regenerate) ---
     await prisma.emailVerificationToken.deleteMany({});


### PR DESCRIPTION
`VeoIntegration.veoEmail`/`veoPasswordEncrypted` are non-null; nulling them throws. Mask to placeholders instead. (Applied live during the UAT clone; committing it.)