### PR TITLE
feat(traklet): DEV/UAT-only widget + auto env-label issues

### DIFF
--- a/.github/workflows/traklet-env-label.yml
+++ b/.github/workflows/traklet-env-label.yml
@@ -1,0 +1,42 @@
+name: Traklet env label
+
+# Tags each newly-opened issue with the environment it was reported from
+# (env:dev / env:uat), derived from the reporting URL that Traklet writes into
+# the issue body ("- **URL:** https://dev.fieldview.live/..."). Keeps a single
+# tracker with per-environment labels instead of separate per-env issues.
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.issue.body || '';
+            const m = body.match(/(?:\*\*URL:\*\*|URL:)\s*(\S+)/i);
+            if (!m) { core.info('No URL in issue body; skipping env label.'); return; }
+            let host = '';
+            try { host = new URL(m[1]).host.toLowerCase(); } catch { return; }
+
+            let label = null;
+            if (/^dev\./.test(host)) label = 'env:dev';
+            else if (/^uat\./.test(host)) label = 'env:uat';
+            if (!label) { core.info(`Host ${host} is not dev/uat; no env label.`); return; }
+
+            const existing = (context.payload.issue.labels || []).map((l) => l.name);
+            if (existing.includes(label)) return;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [label],
+            });
+            core.info(`Added ${label} (host: ${host}).`);

--- a/apps/web/components/TrakletWidget.tsx
+++ b/apps/web/components/TrakletWidget.tsx
@@ -3,31 +3,32 @@
 import { useEffect, useRef } from 'react';
 
 /**
- * Shared Traklet widget — one service-account token, testers identify
- * themselves via the in-widget onboarding (name / email) so issues and
- * test results are attributed to the right person.
+ * Traklet issue/test widget — DEV/UAT only.
  *
- * Loads when NEXT_PUBLIC_TRAKLET_GITHUB_TOKEN is present (GitHub adapter).
- * Falls back to localStorage-only mode when the token is absent.
+ * Initializes ONLY when `NEXT_PUBLIC_TRAKLET_ENABLED === 'true'` AND a GitHub
+ * token is present. Both are set on dev/uat builds and absent on production, so
+ * neither the widget nor the (client-exposed) PAT ever ship to prod. Issues file
+ * to the single repo `YOLOVibeCode/fieldview-live`; a GitHub Action tags each
+ * with an `env:dev` / `env:uat` label based on the reporting URL.
  */
 export function TrakletWidget() {
   const instanceRef = useRef<{ destroy(): void } | null>(null);
   const initRef = useRef(false);
 
   useEffect(() => {
+    const token = process.env.NEXT_PUBLIC_TRAKLET_GITHUB_TOKEN;
+    const enabled = process.env.NEXT_PUBLIC_TRAKLET_ENABLED === 'true';
+    if (!enabled || !token) return; // off in production (flag unset, token absent)
     if (initRef.current) return;
     initRef.current = true;
     let cancelled = false;
 
-    const token = process.env.NEXT_PUBLIC_TRAKLET_GITHUB_TOKEN;
-
     import('traklet')
       .then(async ({ Traklet }) => {
         if (cancelled) return;
-
         const inst = await Traklet.init({
-          adapter: token ? 'github' : 'localStorage',
-          ...(token ? { token } : {}),
+          adapter: 'github',
+          token,
           projects: [
             {
               id: 'fieldview-live',
@@ -37,18 +38,8 @@ export function TrakletWidget() {
           ],
           position: 'top-right',
         });
-
-        if (cancelled) {
-          inst.destroy();
-        } else {
-          instanceRef.current = inst;
-          if (!token) {
-            console.warn(
-              '[Traklet] NEXT_PUBLIC_TRAKLET_GITHUB_TOKEN is not set. ' +
-              'Widget is running in local-only mode — issues will not sync to GitHub.',
-            );
-          }
-        }
+        if (cancelled) inst.destroy();
+        else instanceRef.current = inst;
       })
       .catch((err: unknown) => {
         console.warn('[Traklet] Failed to initialize:', err);


### PR DESCRIPTION
Gates the Traklet widget to DEV/UAT (kills the prod token leak + hides the widget in prod) and adds a workflow that labels each new issue `env:dev`/`env:uat` by reporting URL. Requires the per-env Railway flags (dev/uat enable + remove prod token) + promotion to main (issue-event workflows run from the default branch).