### PR TITLE
promote: env-aware email via relay → PROD

### DIFF
--- a/apps/api/src/lib/__tests__/env.test.ts
+++ b/apps/api/src/lib/__tests__/env.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { normalizeServerEnv, resolveServerEnv } from '../env';
+
+describe('normalizeServerEnv', () => {
+  it('maps known synonyms to dev|uat|production', () => {
+    expect(normalizeServerEnv('production')).toBe('production');
+    expect(normalizeServerEnv('prod')).toBe('production');
+    expect(normalizeServerEnv('uat')).toBe('uat');
+    expect(normalizeServerEnv('staging')).toBe('uat');
+    expect(normalizeServerEnv('qa')).toBe('uat');
+    expect(normalizeServerEnv('preview')).toBe('uat');
+    expect(normalizeServerEnv('dev')).toBe('dev');
+    expect(normalizeServerEnv('development')).toBe('dev');
+    expect(normalizeServerEnv('local')).toBe('dev');
+    expect(normalizeServerEnv('DEV')).toBe('dev'); // case-insensitive
+  });
+
+  it('defaults unknown / empty / null to production (never silently capture prod mail)', () => {
+    expect(normalizeServerEnv('wat')).toBe('production');
+    expect(normalizeServerEnv('')).toBe('production');
+    expect(normalizeServerEnv(undefined)).toBe('production');
+    expect(normalizeServerEnv(null)).toBe('production');
+  });
+});
+
+describe('resolveServerEnv', () => {
+  const saved = {
+    APP_ENV: process.env.APP_ENV,
+    RAILWAY_ENVIRONMENT: process.env.RAILWAY_ENVIRONMENT,
+    NODE_ENV: process.env.NODE_ENV,
+  };
+
+  beforeEach(() => {
+    delete process.env.APP_ENV;
+    delete process.env.RAILWAY_ENVIRONMENT;
+    delete process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it('prefers APP_ENV over RAILWAY_ENVIRONMENT over NODE_ENV', () => {
+    process.env.APP_ENV = 'uat';
+    process.env.RAILWAY_ENVIRONMENT = 'production';
+    process.env.NODE_ENV = 'development';
+    expect(resolveServerEnv()).toBe('uat');
+  });
+
+  it('falls through to RAILWAY_ENVIRONMENT when APP_ENV is empty', () => {
+    process.env.RAILWAY_ENVIRONMENT = 'development';
+    expect(resolveServerEnv()).toBe('dev');
+  });
+
+  it('falls through to NODE_ENV last', () => {
+    process.env.NODE_ENV = 'production';
+    expect(resolveServerEnv()).toBe('production');
+  });
+
+  it('defaults to production when nothing is set', () => {
+    expect(resolveServerEnv()).toBe('production');
+  });
+});

--- a/apps/api/src/lib/email/RelayEmailProvider.ts
+++ b/apps/api/src/lib/email/RelayEmailProvider.ts
@@ -1,0 +1,67 @@
+/**
+ * Relay Email Provider
+ *
+ * The single email path for deployed FieldView. Instead of talking to SendGrid
+ * directly, every email is POSTed to the Noctusoft relay's native `/email/send`
+ * with an `X-App-Env` header. The *relay* owns the destination decision:
+ *
+ *   dev  → captured in Mailpit (never delivered)
+ *   uat  → delivered, but subject prefixed "[UAT] " + an env banner in the body
+ *   prod → delivered normally
+ *
+ * FieldView therefore holds no SendGrid credential — the relay injects it. Every
+ * call site keeps the same `IEmailProvider.sendEmail(...)` interface; the
+ * environment transparently decides where the mail goes.
+ */
+
+import { resolveServerEnv } from '../env';
+
+import type { IEmailProvider, EmailOptions } from './IEmailProvider';
+
+const RELAY_BASE_URL = (process.env.NOCTUSOFT_RELAY_BASE_URL || '').replace(/\/+$/, '');
+const RELAY_API_KEY = process.env.NOCTUSOFT_API_KEY || '';
+const FROM_EMAIL =
+  process.env.EMAIL_FROM || process.env.SENDGRID_FROM_EMAIL || 'noreply@fieldview.live';
+
+export class RelayEmailProvider implements IEmailProvider {
+  async sendEmail(options: EmailOptions): Promise<void> {
+    if (!RELAY_BASE_URL) {
+      throw new Error('NOCTUSOFT_RELAY_BASE_URL is not configured');
+    }
+    if (!RELAY_API_KEY) {
+      throw new Error('NOCTUSOFT_API_KEY is not configured');
+    }
+
+    const appEnv = resolveServerEnv();
+
+    let res: Response;
+    try {
+      res = await fetch(`${RELAY_BASE_URL}/email/send`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${RELAY_API_KEY}`,
+          // The environment router — the relay reads this to pick Mailpit / tag / send.
+          'X-App-Env': appEnv,
+        },
+        body: JSON.stringify({
+          to: options.to,
+          subject: options.subject,
+          html: options.html || undefined,
+          text: options.text || undefined,
+          from: options.from || FROM_EMAIL,
+        }),
+      });
+    } catch (error) {
+      // Network / DNS failure reaching the relay.
+      throw new Error(
+        `Relay email request failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    if (res.status < 200 || res.status >= 300) {
+      const detail = await res.text().catch(() => '');
+      throw new Error(`Relay email failed (${res.status}): ${detail.slice(0, 300)}`);
+    }
+  }
+}

--- a/apps/api/src/lib/email/__tests__/RelayEmailProvider.test.ts
+++ b/apps/api/src/lib/email/__tests__/RelayEmailProvider.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { IEmailProvider } from '../IEmailProvider';
+
+/**
+ * RelayEmailProvider reads NOCTUSOFT_RELAY_BASE_URL / NOCTUSOFT_API_KEY at
+ * module load, so each test sets env then imports a fresh module instance.
+ */
+async function freshProvider(): Promise<IEmailProvider> {
+  vi.resetModules();
+  const mod = await import('../RelayEmailProvider');
+  return new mod.RelayEmailProvider();
+}
+
+const SAVED = {
+  NOCTUSOFT_RELAY_BASE_URL: process.env.NOCTUSOFT_RELAY_BASE_URL,
+  NOCTUSOFT_API_KEY: process.env.NOCTUSOFT_API_KEY,
+  APP_ENV: process.env.APP_ENV,
+  RAILWAY_ENVIRONMENT: process.env.RAILWAY_ENVIRONMENT,
+  NODE_ENV: process.env.NODE_ENV,
+};
+
+function clearEnv() {
+  for (const k of Object.keys(SAVED)) delete process.env[k];
+}
+
+describe('RelayEmailProvider', () => {
+  beforeEach(() => {
+    clearEnv();
+    process.env.NOCTUSOFT_RELAY_BASE_URL = 'https://api.noctusoft.com';
+    process.env.NOCTUSOFT_API_KEY = 'deploy-key-123';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    clearEnv();
+    for (const [k, v] of Object.entries(SAVED)) {
+      if (v !== undefined) process.env[k] = v;
+    }
+  });
+
+  it('POSTs to <base>/email/send with Bearer auth and X-App-Env, mapping fields', async () => {
+    process.env.RAILWAY_ENVIRONMENT = 'production';
+    const fetchMock = vi.fn().mockResolvedValue({ status: 201, text: async () => '' });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = await freshProvider();
+    await provider.sendEmail({ to: 'a@b.com', subject: 'Hi', html: '<p>hi</p>', text: 'hi' });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.noctusoft.com/email/send');
+    expect(init.method).toBe('POST');
+    expect(init.headers.Authorization).toBe('Bearer deploy-key-123');
+    expect(init.headers['X-App-Env']).toBe('production');
+    const body = JSON.parse(init.body);
+    expect(body).toMatchObject({ to: 'a@b.com', subject: 'Hi', html: '<p>hi</p>', text: 'hi' });
+    expect(body.from).toBe('noreply@fieldview.live');
+  });
+
+  it('sends X-App-Env: dev when running in the development env', async () => {
+    process.env.RAILWAY_ENVIRONMENT = 'development';
+    const fetchMock = vi.fn().mockResolvedValue({ status: 201, text: async () => '' });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = await freshProvider();
+    await provider.sendEmail({ to: 'a@b.com', subject: 'Hi', text: 'hi' });
+
+    expect(fetchMock.mock.calls[0][1].headers['X-App-Env']).toBe('dev');
+  });
+
+  it('sends X-App-Env: uat and lets the relay tag (provider stays env-agnostic)', async () => {
+    process.env.RAILWAY_ENVIRONMENT = 'uat';
+    const fetchMock = vi.fn().mockResolvedValue({ status: 201, text: async () => '' });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = await freshProvider();
+    await provider.sendEmail({ to: 'a@b.com', subject: 'Hi', text: 'hi' });
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers['X-App-Env']).toBe('uat');
+    // The provider does NOT pre-tag the subject — that's the relay's job.
+    expect(JSON.parse(init.body).subject).toBe('Hi');
+  });
+
+  it('throws when NOCTUSOFT_RELAY_BASE_URL is missing', async () => {
+    delete process.env.NOCTUSOFT_RELAY_BASE_URL;
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = await freshProvider();
+    await expect(provider.sendEmail({ to: 'a@b.com', subject: 'Hi', text: 'hi' })).rejects.toThrow(
+      /NOCTUSOFT_RELAY_BASE_URL/,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('throws when NOCTUSOFT_API_KEY is missing', async () => {
+    delete process.env.NOCTUSOFT_API_KEY;
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = await freshProvider();
+    await expect(provider.sendEmail({ to: 'a@b.com', subject: 'Hi', text: 'hi' })).rejects.toThrow(
+      /NOCTUSOFT_API_KEY/,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('throws on a non-2xx relay response, surfacing status + detail', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue({ status: 502, text: async () => 'Email failed: upstream down' });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = await freshProvider();
+    await expect(provider.sendEmail({ to: 'a@b.com', subject: 'Hi', text: 'hi' })).rejects.toThrow(
+      /Relay email failed \(502\).*upstream down/,
+    );
+  });
+
+  it('normalizes a trailing slash on the base URL', async () => {
+    process.env.NOCTUSOFT_RELAY_BASE_URL = 'https://api.noctusoft.com/';
+    const fetchMock = vi.fn().mockResolvedValue({ status: 201, text: async () => '' });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const provider = await freshProvider();
+    await provider.sendEmail({ to: 'a@b.com', subject: 'Hi', text: 'hi' });
+
+    expect(fetchMock.mock.calls[0][0]).toBe('https://api.noctusoft.com/email/send');
+  });
+});

--- a/apps/api/src/lib/email/index.ts
+++ b/apps/api/src/lib/email/index.ts
@@ -6,24 +6,40 @@
 
 import type { IEmailProvider } from './IEmailProvider';
 import { MailpitEmailProvider } from './MailpitEmailProvider';
+import { RelayEmailProvider } from './RelayEmailProvider';
 import { SendGridEmailProvider } from './SendGridEmailProvider';
 
 let emailProviderInstance: IEmailProvider | null = null;
 
+/**
+ * Resolve the email provider.
+ *
+ * Default is `relay`: all deployed environments route through the Noctusoft
+ * relay's `/email/send`, which uses the `X-App-Env` header to decide the
+ * destination (dev→Mailpit, uat→tagged, prod→normal). FieldView holds no
+ * SendGrid key — the relay injects it.
+ *
+ * Escape hatches (set `EMAIL_PROVIDER`):
+ *   - `mailpit`  — local laptop with no relay access (direct SMTP to Mailpit)
+ *   - `sendgrid` — emergency direct SendGrid (requires SENDGRID_API_KEY)
+ */
 export function getEmailProvider(): IEmailProvider {
   if (emailProviderInstance) {
     return emailProviderInstance;
   }
 
-  const emailProvider = process.env.EMAIL_PROVIDER || 'mailpit';
+  const emailProvider = process.env.EMAIL_PROVIDER || 'relay';
 
   switch (emailProvider.toLowerCase()) {
     case 'sendgrid':
       emailProviderInstance = new SendGridEmailProvider();
       break;
     case 'mailpit':
-    default:
       emailProviderInstance = new MailpitEmailProvider();
+      break;
+    case 'relay':
+    default:
+      emailProviderInstance = new RelayEmailProvider();
       break;
   }
 

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -1,0 +1,50 @@
+/**
+ * Server-side environment resolution for the API.
+ *
+ * Mirrors the web app's `apps/web/lib/env-chrome/resolve.ts` so both halves of
+ * the stack agree on which environment they are running in. The API has no DOM
+ * chrome to render — this exists so env-aware backend behaviour (chiefly the
+ * `X-App-Env` header the relay uses to route email to Mailpit / tag UAT / send
+ * prod) has one authoritative source instead of scattered `NODE_ENV` checks.
+ *
+ * Priority: APP_ENV → RAILWAY_ENVIRONMENT → NODE_ENV.
+ *
+ * Default is **production**. Deployed Railway services always set
+ * RAILWAY_ENVIRONMENT, so the default only bites when nothing is set (a local
+ * process or a broken deploy). Defaulting to production is the safe failure for
+ * *email*: the alternative — resolving an unlabelled prod process to `dev` —
+ * would silently capture real password-reset / receipt mail in Mailpit and lock
+ * users out. Local development should instead set `EMAIL_PROVIDER=mailpit` (see
+ * the email factory) so it never touches the relay at all.
+ */
+
+export type ServerEnv = 'dev' | 'uat' | 'production';
+
+const SYNONYMS: Record<string, ServerEnv> = {
+  production: 'production',
+  prod: 'production',
+  uat: 'uat',
+  staging: 'uat',
+  qa: 'uat',
+  preview: 'uat',
+  dev: 'dev',
+  development: 'dev',
+  local: 'dev',
+  test: 'dev',
+};
+
+export function normalizeServerEnv(raw: string | undefined | null): ServerEnv {
+  if (raw === undefined || raw === null) return 'production';
+  const s = String(raw).trim().toLowerCase();
+  if (!s) return 'production';
+  return SYNONYMS[s] ?? 'production';
+}
+
+export function resolveServerEnv(): ServerEnv {
+  const raw =
+    process.env.APP_ENV ||
+    process.env.RAILWAY_ENVIRONMENT ||
+    process.env.NODE_ENV ||
+    '';
+  return normalizeServerEnv(raw);
+}

--- a/apps/web/lib/env-chrome/EnvChrome.tsx
+++ b/apps/web/lib/env-chrome/EnvChrome.tsx
@@ -13,12 +13,17 @@ import { applyEnvChrome, envFromHost, type AppEnv } from './chrome';
  * then reconcile if the server disagrees. `HOST_RULES` is imported directly
  * here (client side) — it contains `RegExp`s, which can't be serialized across
  * the Server→Client boundary, so it must NOT be passed as a prop.
+ *
+ * `NEXT_PUBLIC_MAILPIT_URL` (build-time, set on dev/uat only) adds a "📧 Mailpit"
+ * link to the banner pointing at that environment's captured-mail inbox. Absent
+ * on prod → no link.
  */
 export function EnvChrome({ env }: { env: AppEnv }) {
   useEffect(() => {
+    const opts = { mailpitUrl: process.env.NEXT_PUBLIC_MAILPIT_URL };
     const instant = envFromHost(location.hostname, HOST_RULES);
-    applyEnvChrome(instant);
-    if (env !== instant) applyEnvChrome(env);
+    applyEnvChrome(instant, opts);
+    if (env !== instant) applyEnvChrome(env, opts);
   }, [env]);
 
   return null;

--- a/apps/web/lib/env-chrome/chrome.test.ts
+++ b/apps/web/lib/env-chrome/chrome.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { badgeFor, envFromHost, faviconDataUri } from './chrome';
+import { afterEach, describe, expect, it } from 'vitest';
+import { applyEnvChrome, badgeFor, envFromHost, faviconDataUri } from './chrome';
 import { HOST_RULES } from '@/env-chrome.config';
 
 describe('envFromHost — FieldView.Live hostname rules', () => {
@@ -45,5 +45,42 @@ describe('faviconDataUri', () => {
     const svg = decodeURIComponent(uri.slice('data:image/svg+xml,'.length));
     expect(svg).toContain('#b45309');
     expect(svg).toContain('>U<');
+  });
+});
+
+describe('applyEnvChrome — Mailpit link (dev toolbar)', () => {
+  afterEach(() => {
+    document.getElementById('env-banner')?.remove();
+    document.title = 'FieldView';
+  });
+
+  it('renders a 📧 Mailpit link on dev when mailpitUrl is provided', () => {
+    applyEnvChrome('dev', { mailpitUrl: 'https://mailpit.noctusoft.com' });
+    const link = document.getElementById('env-mailpit-link') as HTMLAnchorElement | null;
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute('href')).toBe('https://mailpit.noctusoft.com');
+    expect(link!.getAttribute('target')).toBe('_blank');
+    expect(link!.getAttribute('rel')).toContain('noopener');
+    expect(link!.textContent).toContain('Mailpit');
+    // banner still shows the env label alongside the link
+    expect(document.getElementById('env-banner')?.textContent).toMatch(/Development/i);
+  });
+
+  it('renders no link on dev when mailpitUrl is absent (prod builds pass nothing)', () => {
+    applyEnvChrome('dev');
+    expect(document.getElementById('env-banner')).not.toBeNull();
+    expect(document.getElementById('env-mailpit-link')).toBeNull();
+  });
+
+  it('does not duplicate the link when re-applied', () => {
+    applyEnvChrome('dev', { mailpitUrl: 'https://mailpit.noctusoft.com' });
+    applyEnvChrome('dev', { mailpitUrl: 'https://mailpit.noctusoft.com' });
+    expect(document.querySelectorAll('#env-mailpit-link').length).toBe(1);
+  });
+
+  it('shows no banner or link on production (link URL ignored)', () => {
+    applyEnvChrome('production', { mailpitUrl: 'https://mailpit.noctusoft.com' });
+    expect(document.getElementById('env-banner')).toBeNull();
+    expect(document.getElementById('env-mailpit-link')).toBeNull();
   });
 });

--- a/apps/web/lib/env-chrome/chrome.ts
+++ b/apps/web/lib/env-chrome/chrome.ts
@@ -51,8 +51,16 @@ function faviconLink(): HTMLLinkElement {
   return link;
 }
 
+/**
+ * Optional per-environment tools shown inline in the banner. `mailpitUrl`, when
+ * provided on a non-prod env, renders a "📧 Mailpit" link to that environment's
+ * captured-mail inbox. Opt-in and additive: other projects call
+ * `applyEnvChrome(env)` with no opts and are unaffected.
+ */
+export type EnvChromeOptions = { mailpitUrl?: string };
+
 /** Apply (or clear, for production) the banner + title prefix + favicon tint. */
-export function applyEnvChrome(env: AppEnv): void {
+export function applyEnvChrome(env: AppEnv, opts: EnvChromeOptions = {}): void {
   if (baseTitle === null) baseTitle = document.title.replace(/^\[[A-Z]+\]\s+/, '');
   const link = faviconLink();
   if (baseFavicon === null) baseFavicon = link.getAttribute('href') || '/favicon.ico';
@@ -70,7 +78,6 @@ export function applyEnvChrome(env: AppEnv): void {
   const banner = existing ?? document.createElement('div');
   banner.id = 'env-banner';
   banner.setAttribute('role', 'status');
-  banner.textContent = badge.label;
   banner.style.cssText = [
     `background:${badge.color}`,
     'color:#fff',
@@ -81,7 +88,36 @@ export function applyEnvChrome(env: AppEnv): void {
     'padding:5px 12px',
     'width:100%',
     'box-sizing:border-box',
+    'display:flex',
+    'align-items:center',
+    'justify-content:center',
+    'gap:16px',
   ].join(';');
+
+  // Rebuild children each apply (handles re-apply without duplicating the link).
+  banner.textContent = '';
+  const label = document.createElement('span');
+  label.textContent = badge.label;
+  banner.appendChild(label);
+
+  const mailpitUrl = opts.mailpitUrl?.trim();
+  if (mailpitUrl) {
+    const a = document.createElement('a');
+    a.id = 'env-mailpit-link';
+    a.href = mailpitUrl;
+    a.target = '_blank';
+    a.rel = 'noopener noreferrer';
+    a.textContent = '📧 Mailpit';
+    a.style.cssText = [
+      'color:#fff',
+      'text-decoration:underline',
+      'text-transform:none',
+      'letter-spacing:normal',
+      'white-space:nowrap',
+    ].join(';');
+    banner.appendChild(a);
+  }
+
   if (!existing) document.body.insertBefore(banner, document.body.firstChild);
 
   document.title = `[${badge.short}] ${baseTitle}`;

--- a/docs/RELAY-STORAGE.md
+++ b/docs/RELAY-STORAGE.md
@@ -1,12 +1,19 @@
 # Object storage via the Noctusoft relay
 
 > **Status:** greenfield. FieldView stores **no** blobs today — there is no S3 /
-> asset-upload code anywhere in the repo. The old `AWS_ACCESS_KEY_ID`,
-> `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `S3_BUCKET`, `S3_ENDPOINT`, and
-> `ASSET_STORE` Railway vars were **dead** and have been removed. This document
-> is the standard to follow **when** asset storage is actually needed, so it
-> lands on the relay from day one (same posture as email — see
+> asset-upload code anywhere in the repo. This document is the standard to follow
+> **when** asset storage is actually needed, so it lands on the relay from day
+> one (same posture as email — see
 > [`RELAY-CONNECT-HUB-MIGRATION.md`](./RELAY-CONNECT-HUB-MIGRATION.md)).
+>
+> **Existing dead config (2026-08):** the `ASSET_STORE=s3` var was removed from
+> all api envs. The `AWS_REGION` / `AWS_S3_BUCKET` / `AWS_S3_ENDPOINT` /
+> `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` vars are **injected by a Railway
+> Bucket named `assets`** attached to the `api` service, and are read by **no**
+> code. To fully retire them, detach/delete that bucket in the Railway dashboard
+> (it appears unused; confirm it holds no objects first) — left in place for now
+> because removing a storage resource is an owner decision, and the vars are
+> inert at runtime.
 
 ## Why the relay, not direct S3
 

--- a/docs/RELAY-STORAGE.md
+++ b/docs/RELAY-STORAGE.md
@@ -1,0 +1,66 @@
+# Object storage via the Noctusoft relay
+
+> **Status:** greenfield. FieldView stores **no** blobs today — there is no S3 /
+> asset-upload code anywhere in the repo. The old `AWS_ACCESS_KEY_ID`,
+> `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`, `S3_BUCKET`, `S3_ENDPOINT`, and
+> `ASSET_STORE` Railway vars were **dead** and have been removed. This document
+> is the standard to follow **when** asset storage is actually needed, so it
+> lands on the relay from day one (same posture as email — see
+> [`RELAY-CONNECT-HUB-MIGRATION.md`](./RELAY-CONNECT-HUB-MIGRATION.md)).
+
+## Why the relay, not direct S3
+
+Same reasons email routes through the relay: **FieldView holds no vendor
+credential**, and the **environment is the router**. The relay owns the
+Cloudflare R2 credentials and enforces a per-bucket allowlist; FieldView just
+`PUT`/`GET`s objects with its deploy key. Non-prod never touches prod blobs
+because each environment writes to its **own bucket**.
+
+## The endpoint
+
+The relay exposes an R2-backed object store:
+
+```
+PUT  {NOCTUSOFT_RELAY_BASE_URL}/v1/storage/:bucket/<key…>
+GET  {NOCTUSOFT_RELAY_BASE_URL}/v1/storage/:bucket/<key…>
+```
+
+- **Auth:** `Authorization: Bearer ${NOCTUSOFT_API_KEY}` (the Railway deploy key — works from any IP), exactly like `/email/send`.
+- **Base URL:** `NOCTUSOFT_RELAY_BASE_URL` (= `https://api.noctusoft.com`).
+- **Allowlist:** the relay only serves buckets in its `STORAGE_ALLOWED_BUCKETS`. A bucket not on the list is rejected — this is the guardrail that keeps environments from crossing.
+
+## Per-environment buckets (the partitioning rule)
+
+One bucket per environment. The **environment picks the bucket name**, so a dev
+upload can never land in the prod bucket:
+
+| Env | Bucket |
+|---|---|
+| dev | `fieldview-dev` |
+| uat | `fieldview-uat` |
+| production | `fieldview` |
+
+Resolve the bucket from the same env resolver the email path uses
+(`apps/api/src/lib/env.ts` → `resolveServerEnv()`), e.g.:
+
+```ts
+import { resolveServerEnv } from '../env';
+
+const BUCKET = { dev: 'fieldview-dev', uat: 'fieldview-uat', production: 'fieldview' }[
+  resolveServerEnv()
+];
+```
+
+Unlike email — where a single `/email/send` handles all envs via the `X-App-Env`
+header — storage keys the environment into the **bucket path**, because the blob
+must be physically isolated (an object literally lives in one bucket or another).
+
+## When you build this
+
+1. Add `fieldview-dev`, `fieldview-uat`, `fieldview` to the relay's
+   `STORAGE_ALLOWED_BUCKETS` (create the R2 buckets first).
+2. Add a small `RelayStorage` client in `apps/api` mirroring `RelayEmailProvider`
+   — `NOCTUSOFT_RELAY_BASE_URL` + `NOCTUSOFT_API_KEY`, bucket from
+   `resolveServerEnv()`, throw on non-2xx.
+3. Never add `AWS_*` / `S3_*` / `ASSET_STORE` vars back to FieldView — the relay
+   holds all storage credentials.


### PR DESCRIPTION
Promotes env-aware email routing to production. After merge, prod deploys the new code but stays on direct SendGrid (EMAIL_PROVIDER=sendgrid) until the var is removed, so prod email never drops. Then EMAIL_PROVIDER is deleted to route prod through the relay (X-App-Env: production → normal delivery via the same SendGrid account).

Relay delivery of fieldview.live is SendGrid-confirmed (activity feed: delivered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)