### PR TITLE
feat(veo): browser-free HTTP connector (OIDC cookie → Mux link)

### DIFF
--- a/apps/api/scripts/seed-veo-session-cookie.ts
+++ b/apps/api/scripts/seed-veo-session-cookie.ts
@@ -1,0 +1,55 @@
+/**
+ * Seed a VeoIntegration's browser-free credential.
+ *
+ * Runs the ONE-TIME Veo browser login (locally — needs Chromium on THIS machine,
+ * not in prod), captures the `auth.veo.co` `_session` cookie, encrypts it, and
+ * stores it on VeoIntegration.veoSessionCookieEncrypted. After this the prod
+ * connector runs pure HTTP (VEO_HTTP_MODE) with no Chromium in the container.
+ *
+ * Usage (email inline to avoid dotenv `$` corruption; password read from .env):
+ *   VEO_EMAIL=rvegajr@noctusoft.com \
+ *   [VEO_OWNER_ACCOUNT_ID=<uuid>] [DATABASE_URL=<target db>] \
+ *   pnpm exec dotenv -e .env -- tsx scripts/seed-veo-session-cookie.ts
+ */
+import { prisma } from '../src/lib/prisma';
+import { encrypt } from '../src/lib/encryption';
+import { PlaywrightVeoAuthenticator } from '../src/modules/veo-scraper/implementations/PlaywrightVeoAuthenticator';
+import { VeoCookieSeeder } from '../src/modules/veo-scraper/implementations/VeoCookieSeeder';
+
+async function main(): Promise<void> {
+  const email = (process.env.VEO_EMAIL || '').trim();
+  const password = process.env.VEO_PASSWORD || ''; // literal from .env (may contain `$`)
+  if (!email || !password) throw new Error('VEO_EMAIL and VEO_PASSWORD are required');
+
+  const ownerAccountId = process.env.VEO_OWNER_ACCOUNT_ID?.trim();
+  const integration = ownerAccountId
+    ? await prisma.veoIntegration.findUnique({ where: { ownerAccountId } })
+    : await prisma.veoIntegration.findFirst();
+  if (!integration) {
+    throw new Error(
+      ownerAccountId
+        ? `No VeoIntegration for ownerAccountId=${ownerAccountId}`
+        : 'No VeoIntegration found (set VEO_OWNER_ACCOUNT_ID)'
+    );
+  }
+
+  console.log(`Seeding session cookie for ownerAccountId=${integration.ownerAccountId} (browser login)…`);
+  const seeder = new VeoCookieSeeder(new PlaywrightVeoAuthenticator());
+  const cookieHeader = await seeder.seed({ email, password });
+  console.log(`Captured session cookie (${cookieHeader.length} chars). Encrypting + storing…`);
+
+  await prisma.veoIntegration.update({
+    where: { id: integration.id },
+    data: { veoSessionCookieEncrypted: encrypt(cookieHeader) },
+  });
+
+  console.log('✅ Stored VeoIntegration.veoSessionCookieEncrypted. Prod can now run VEO_HTTP_MODE=true (no Chromium).');
+}
+
+main()
+  .catch((e: unknown) => {
+    const err = e as { name?: string; message?: string };
+    console.error('ERR', err?.name, err?.message);
+    process.exit(1);
+  })
+  .finally(() => void prisma.$disconnect());

--- a/apps/api/scripts/verify-veo-http.ts
+++ b/apps/api/scripts/verify-veo-http.ts
@@ -1,0 +1,42 @@
+/**
+ * Verify the BROWSER-FREE Veo HTTP connector against live Veo.
+ *
+ * Exercises the real production classes (HttpVeoAuthenticator + HttpVeoStreamScraper
+ * + HttpVeoStreamHistoryClient) driven only by a seeded `_session` cookie — no browser.
+ *
+ *   COOKIE_FILE=/path/to/cookie [VEO_DIAGNOSTICS_URL=…] npx tsx scripts/verify-veo-http.ts
+ */
+import * as fs from 'fs';
+
+import { HttpVeoAuthenticator } from '../src/modules/veo-scraper/implementations/HttpVeoAuthenticator';
+import { HttpVeoStreamHistoryClient } from '../src/modules/veo-scraper/implementations/HttpVeoStreamHistoryClient';
+import { HttpVeoStreamScraper } from '../src/modules/veo-scraper/implementations/HttpVeoStreamScraper';
+import type { FetchLike } from '../src/modules/veo-scraper/interfaces';
+
+async function main(): Promise<void> {
+  const cookieFile = process.env.COOKIE_FILE;
+  if (!cookieFile) throw new Error('COOKIE_FILE=<path to _session cookie header> required');
+  const sessionCookie = fs.readFileSync(cookieFile, 'utf8').trim();
+  const diagnosticsUrl =
+    process.env.VEO_DIAGNOSTICS_URL ||
+    'https://app.veo.co/clubs/noctusoft-inc/live/streaming-diagnostics';
+
+  const auth = new HttpVeoAuthenticator();
+  const scraper = new HttpVeoStreamScraper({
+    streamClient: new HttpVeoStreamHistoryClient({ fetch: globalThis.fetch as unknown as FetchLike }),
+  });
+
+  const session = await auth.login({ email: '', password: '', sessionCookie });
+  const rows = await scraper.scrape(session, diagnosticsUrl);
+  await auth.logout(session);
+
+  console.log(`live rows (status !== 'finished' && has url): ${rows.length}`);
+  for (const r of rows.slice(0, 5)) console.log('  -', r.matchName, '| status', r.status, '|', r.streamUrl);
+  console.log('\n✅ Real HTTP connector ran against live Veo, cookie-only, no browser.');
+}
+
+main().catch((e: unknown) => {
+  const err = e as { name?: string; message?: string };
+  console.error('ERR', err?.name, err?.message);
+  process.exit(1);
+});

--- a/apps/api/src/jobs/veo-stream-poll.ts
+++ b/apps/api/src/jobs/veo-stream-poll.ts
@@ -63,8 +63,20 @@ export async function checkAndPollVeoStreams(): Promise<void> {
       continue;
     }
 
+    // Prefer the browser-free HTTP path when a seeded session cookie exists.
+    // Falls back to Playwright only when there is no cookie (dev; needs Chromium).
+    let sessionCookie: string | undefined;
+    if (veo.veoSessionCookieEncrypted) {
+      try {
+        sessionCookie = decrypt(veo.veoSessionCookieEncrypted);
+      } catch (err) {
+        logger.warn({ err, ownerAccountId }, 'Veo polling: failed to decrypt Veo session cookie — falling back');
+      }
+    }
+    const httpMode = !!sessionCookie;
+
     const config = {
-      credentials: { email: veo.veoEmail, password: veoPassword },
+      credentials: { email: veo.veoEmail, password: veoPassword, sessionCookie },
       diagnosticsUrl: veo.veoDiagnosticsUrl,
       ownerAccountId,
       minConfidence: 0.7,
@@ -74,7 +86,8 @@ export async function checkAndPollVeoStreams(): Promise<void> {
     };
 
     try {
-      const poller = createVeoPollingOrchestrator();
+      const poller = createVeoPollingOrchestrator({ httpMode });
+      logger.info({ ownerAccountId, mode: httpMode ? 'http' : 'playwright' }, 'Veo polling mode selected');
       await veoPollingSessionManager.startPolling(ownerAccountId, poller, config);
       logger.info(
         { ownerAccountId, eventCount: events.filter((e) => e.directStream.ownerAccountId === ownerAccountId).length },

--- a/apps/api/src/modules/veo-scraper/__tests__/CachingVeoTokenProvider.test.ts
+++ b/apps/api/src/modules/veo-scraper/__tests__/CachingVeoTokenProvider.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { CachingVeoTokenProvider } from '../implementations/CachingVeoTokenProvider';
+import type { IVeoTokenMinter, MintedToken } from '../interfaces';
+
+function minterReturning(...tokens: MintedToken[]): { minter: IVeoTokenMinter; mint: any } {
+  let i = 0;
+  const mint = vi.fn(async () => tokens[Math.min(i++, tokens.length - 1)]);
+  return { minter: { mint }, mint };
+}
+
+const COOKIE = '_session=abc';
+
+describe('CachingVeoTokenProvider', () => {
+  it('mints once, then serves the cached token within its lifetime', async () => {
+    const { minter, mint } = minterReturning({ accessToken: 'AT1', expiresInSec: 3600 });
+    let t = 1000;
+    const p = new CachingVeoTokenProvider({ minter, sessionCookie: COOKIE, now: () => t });
+
+    expect(await p.getAccessToken()).toBe('AT1');
+    t += 60_000; // +1 min, well within the hour
+    expect(await p.getAccessToken()).toBe('AT1');
+    expect(mint).toHaveBeenCalledTimes(1);
+    expect(mint).toHaveBeenCalledWith(COOKIE);
+  });
+
+  it('re-mints once the token is within the safety margin of expiry', async () => {
+    const { minter, mint } = minterReturning(
+      { accessToken: 'AT1', expiresInSec: 3600 },
+      { accessToken: 'AT2', expiresInSec: 3600 }
+    );
+    let t = 0;
+    const p = new CachingVeoTokenProvider({ minter, sessionCookie: COOKIE, now: () => t, safetyMarginSec: 60 });
+
+    expect(await p.getAccessToken()).toBe('AT1');
+    t += (3600 - 30) * 1000; // inside the 60s safety margin
+    expect(await p.getAccessToken()).toBe('AT2');
+    expect(mint).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidate() forces a re-mint on the next call (e.g. after a 401)', async () => {
+    const { minter, mint } = minterReturning(
+      { accessToken: 'AT1', expiresInSec: 3600 },
+      { accessToken: 'AT2', expiresInSec: 3600 }
+    );
+    let t = 0;
+    const p = new CachingVeoTokenProvider({ minter, sessionCookie: COOKIE, now: () => t });
+
+    expect(await p.getAccessToken()).toBe('AT1');
+    p.invalidate();
+    expect(await p.getAccessToken()).toBe('AT2');
+    expect(mint).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache a failed mint (retries next call)', async () => {
+    const mint = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ accessToken: 'AT-ok', expiresInSec: 3600 });
+    const p = new CachingVeoTokenProvider({ minter: { mint }, sessionCookie: COOKIE, now: () => 0 });
+
+    await expect(p.getAccessToken()).rejects.toThrow('boom');
+    expect(await p.getAccessToken()).toBe('AT-ok');
+    expect(mint).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/api/src/modules/veo-scraper/__tests__/HttpVeoAdapters.test.ts
+++ b/apps/api/src/modules/veo-scraper/__tests__/HttpVeoAdapters.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { HttpVeoAuthenticator } from '../implementations/HttpVeoAuthenticator';
+import { HttpVeoStreamScraper } from '../implementations/HttpVeoStreamScraper';
+import {
+  VeoSessionExpiredError,
+  type IVeoAccessTokenProvider,
+  type IVeoStreamHistoryClient,
+  type VeoMatchRow,
+} from '../interfaces';
+
+const DIAG = 'https://app.veo.co/clubs/noctusoft-inc/live/streaming-diagnostics';
+const ROW: VeoMatchRow = { matchName: 'A vs B', status: 'live', streamUrl: 'https://stream.mux.com/X.m3u8', uploadSpeed: null, firmware: '' };
+
+describe('HttpVeoAuthenticator', () => {
+  it('login builds a session carrying a token provider from the seeded cookie', async () => {
+    const provider: IVeoAccessTokenProvider = { getAccessToken: vi.fn(async () => 'AT') };
+    const createTokenProvider = vi.fn(() => provider);
+    const auth = new HttpVeoAuthenticator({ createTokenProvider });
+
+    const session = await auth.login({ email: '', password: '', sessionCookie: '_session=abc' });
+    expect(createTokenProvider).toHaveBeenCalledWith('_session=abc');
+    expect((session.context as any).provider).toBe(provider);
+    await expect(auth.logout(session)).resolves.toBeUndefined(); // no-op, no browser to close
+  });
+
+  it('login without a seeded session cookie fails clearly', async () => {
+    const auth = new HttpVeoAuthenticator({ createTokenProvider: vi.fn() });
+    await expect(auth.login({ email: 'x', password: 'y' })).rejects.toThrow(/session cookie/i);
+  });
+});
+
+function sessionWith(provider: IVeoAccessTokenProvider) {
+  return { context: { provider } };
+}
+
+describe('HttpVeoStreamScraper', () => {
+  it('resolves club slug + token, then returns the client rows', async () => {
+    const provider: IVeoAccessTokenProvider = { getAccessToken: vi.fn(async () => 'AT') };
+    const client: IVeoStreamHistoryClient = { fetchLiveStreams: vi.fn(async () => [ROW]) };
+    const rows = await new HttpVeoStreamScraper({ streamClient: client }).scrape(sessionWith(provider), DIAG);
+    expect(client.fetchLiveStreams).toHaveBeenCalledWith('AT', 'noctusoft-inc');
+    expect(rows).toEqual([ROW]);
+  });
+
+  it('on a 401 (expired access token) it invalidates, re-mints, and retries once', async () => {
+    const invalidate = vi.fn();
+    const provider = { getAccessToken: vi.fn().mockResolvedValueOnce('OLD').mockResolvedValueOnce('NEW'), invalidate } as IVeoAccessTokenProvider & { invalidate: any };
+    const fetchLiveStreams = vi
+      .fn()
+      .mockRejectedValueOnce(new VeoSessionExpiredError('401'))
+      .mockResolvedValueOnce([ROW]);
+    const rows = await new HttpVeoStreamScraper({ streamClient: { fetchLiveStreams } }).scrape(sessionWith(provider), DIAG);
+    expect(invalidate).toHaveBeenCalledTimes(1);
+    expect(fetchLiveStreams).toHaveBeenNthCalledWith(1, 'OLD', 'noctusoft-inc');
+    expect(fetchLiveStreams).toHaveBeenNthCalledWith(2, 'NEW', 'noctusoft-inc');
+    expect(rows).toEqual([ROW]);
+  });
+
+  it('propagates VeoSessionExpiredError when the re-mint also fails (cookie truly dead)', async () => {
+    const provider = {
+      getAccessToken: vi.fn().mockResolvedValueOnce('OLD').mockRejectedValueOnce(new VeoSessionExpiredError()),
+      invalidate: vi.fn(),
+    } as IVeoAccessTokenProvider & { invalidate: any };
+    const fetchLiveStreams = vi.fn().mockRejectedValueOnce(new VeoSessionExpiredError('401'));
+    await expect(
+      new HttpVeoStreamScraper({ streamClient: { fetchLiveStreams } }).scrape(sessionWith(provider), DIAG)
+    ).rejects.toBeInstanceOf(VeoSessionExpiredError);
+  });
+
+  it('throws if the diagnostics URL has no club slug', async () => {
+    const provider: IVeoAccessTokenProvider = { getAccessToken: vi.fn(async () => 'AT') };
+    const client: IVeoStreamHistoryClient = { fetchLiveStreams: vi.fn() };
+    await expect(
+      new HttpVeoStreamScraper({ streamClient: client }).scrape(sessionWith(provider), 'https://app.veo.co/recordings')
+    ).rejects.toThrow(/club/i);
+  });
+});

--- a/apps/api/src/modules/veo-scraper/__tests__/HttpVeoStreamHistoryClient.test.ts
+++ b/apps/api/src/modules/veo-scraper/__tests__/HttpVeoStreamHistoryClient.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { HttpVeoStreamHistoryClient } from '../implementations/HttpVeoStreamHistoryClient';
+import { DEFAULT_VEO_OIDC } from '../implementations/veo-oidc';
+import { VeoSessionExpiredError, type FetchLike, type HttpResponse } from '../interfaces';
+
+const SAMPLE = {
+  result: [
+    { additional_info: { home_team: 'A', away_team: 'B', status: 'finished', broadcast_link: 'https://stream.mux.com/OLD.m3u8' } },
+    { additional_info: { home_team: 'Live FC', away_team: 'Now United', status: 'live', broadcast_link: 'https://stream.mux.com/LIVE.m3u8' } },
+    { additional_info: { home_team: 'No URL', away_team: 'Yet', status: 'live', broadcast_link: '' } },
+  ],
+};
+
+function resp(status: number, json: unknown): HttpResponse {
+  return { status, headers: { get: () => null }, json: async () => json, text: async () => JSON.stringify(json) };
+}
+
+describe('HttpVeoStreamHistoryClient', () => {
+  it('GETs stream-history with the Bearer token and returns only LIVE rows with a URL', async () => {
+    const calls: Array<{ url: string; init?: any }> = [];
+    const fetch: FetchLike = vi.fn(async (url, init) => {
+      calls.push({ url, init });
+      return resp(200, SAMPLE);
+    });
+    const rows = await new HttpVeoStreamHistoryClient({ fetch }).fetchLiveStreams('AT-1', 'noctusoft-inc');
+
+    expect(calls[0].url).toBe(`${DEFAULT_VEO_OIDC.streamHistoryBase}/noctusoft-inc/stream-history`);
+    expect(calls[0].init.headers.Authorization).toBe('Bearer AT-1');
+    // finished dropped, empty-url dropped → only the one live+playable row
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ matchName: 'Live FC vs Now United', status: 'live', streamUrl: 'https://stream.mux.com/LIVE.m3u8' });
+  });
+
+  it('treats 401 as an expired token → VeoSessionExpiredError (caller re-mints)', async () => {
+    const fetch: FetchLike = async () => resp(401, { error: 'invalid_token' });
+    await expect(new HttpVeoStreamHistoryClient({ fetch }).fetchLiveStreams('AT', 'noctusoft-inc')).rejects.toBeInstanceOf(
+      VeoSessionExpiredError
+    );
+  });
+
+  it('treats 403 (no diagnostics access to that club) as no live streams (empty)', async () => {
+    const fetch: FetchLike = async () => resp(403, { detail: 'forbidden' });
+    const rows = await new HttpVeoStreamHistoryClient({ fetch }).fetchLiveStreams('AT', 'some-club');
+    expect(rows).toEqual([]);
+  });
+
+  it('throws on other non-2xx responses', async () => {
+    const fetch: FetchLike = async () => resp(500, { error: 'boom' });
+    await expect(new HttpVeoStreamHistoryClient({ fetch }).fetchLiveStreams('AT', 'c')).rejects.toThrow(/500/);
+  });
+});

--- a/apps/api/src/modules/veo-scraper/__tests__/HttpVeoTokenMinter.test.ts
+++ b/apps/api/src/modules/veo-scraper/__tests__/HttpVeoTokenMinter.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { HttpVeoTokenMinter } from '../implementations/HttpVeoTokenMinter';
+import { DEFAULT_VEO_OIDC } from '../implementations/veo-oidc';
+import { VeoSessionExpiredError, type FetchLike, type HttpResponse } from '../interfaces';
+
+const COOKIE = '_session=abc; _session.sig=def';
+
+function resp(partial: Partial<HttpResponse> & { location?: string }): HttpResponse {
+  return {
+    status: partial.status ?? 200,
+    headers: { get: (n: string) => (n.toLowerCase() === 'location' ? partial.location ?? null : null) },
+    json: partial.json ?? (async () => ({})),
+    text: partial.text ?? (async () => ''),
+  };
+}
+
+/** Fake fetch: 303+code on authorize, access_token on token. Records calls. */
+function happyFetch(overrides?: { location?: string; token?: any }) {
+  const calls: Array<{ url: string; init?: any }> = [];
+  const fetch: FetchLike = vi.fn(async (url: string, init?: any) => {
+    calls.push({ url, init });
+    if (url.startsWith(DEFAULT_VEO_OIDC.authorizeUrl)) {
+      return resp({ status: 303, location: overrides?.location ?? '/signin-redirect/?code=CODE123&state=st' });
+    }
+    if (url === DEFAULT_VEO_OIDC.tokenUrl) {
+      return resp({ status: 200, json: async () => overrides?.token ?? { access_token: 'AT-xyz', expires_in: 3600, token_type: 'Bearer' } });
+    }
+    throw new Error(`unexpected url ${url}`);
+  });
+  return { fetch, calls };
+}
+
+describe('HttpVeoTokenMinter', () => {
+  it('mints an access token: authorize (with cookie+PKCE) → code → token exchange', async () => {
+    const { fetch, calls } = happyFetch();
+    const minter = new HttpVeoTokenMinter({ fetch });
+
+    const token = await minter.mint(COOKIE);
+    expect(token).toEqual({ accessToken: 'AT-xyz', expiresInSec: 3600 });
+
+    // authorize: GET with the session cookie + manual redirect + a PKCE challenge
+    const authCall = calls.find((c) => c.url.startsWith(DEFAULT_VEO_OIDC.authorizeUrl))!;
+    expect(authCall.init.headers.Cookie).toBe(COOKIE);
+    expect(authCall.init.redirect).toBe('manual');
+    const challenge = new URL(authCall.url).searchParams.get('code_challenge');
+    expect(challenge).toBeTruthy();
+
+    // token: POST form with the code + a matching code_verifier + no client secret
+    const tokenCall = calls.find((c) => c.url === DEFAULT_VEO_OIDC.tokenUrl)!;
+    expect(tokenCall.init.method).toBe('POST');
+    const body = new URLSearchParams(tokenCall.init.body);
+    expect(body.get('grant_type')).toBe('authorization_code');
+    expect(body.get('code')).toBe('CODE123');
+    expect(body.get('client_id')).toBe(DEFAULT_VEO_OIDC.clientId);
+    expect(body.get('code_verifier')).toBeTruthy();
+    expect(body.get('client_secret')).toBeNull(); // public client
+  });
+
+  it('binds verifier↔challenge (S256): the sent verifier hashes to the sent challenge', async () => {
+    const { fetch, calls } = happyFetch();
+    await new HttpVeoTokenMinter({ fetch }).mint(COOKIE);
+    const challenge = new URL(calls.find((c) => c.url.startsWith(DEFAULT_VEO_OIDC.authorizeUrl))!.url).searchParams.get('code_challenge')!;
+    const verifier = new URLSearchParams(calls.find((c) => c.url === DEFAULT_VEO_OIDC.tokenUrl)!.init.body).get('code_verifier')!;
+    const { createHash } = await import('crypto');
+    const expected = createHash('sha256').update(verifier).digest('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    expect(challenge).toBe(expected);
+  });
+
+  it('throws VeoSessionExpiredError when authorize yields no code (cookie dead)', async () => {
+    const fetch: FetchLike = async (url) =>
+      url.startsWith(DEFAULT_VEO_OIDC.authorizeUrl)
+        ? resp({ status: 303, location: '/error.html?errorMessage=login_required' })
+        : resp({ status: 200 });
+    await expect(new HttpVeoTokenMinter({ fetch }).mint(COOKIE)).rejects.toBeInstanceOf(VeoSessionExpiredError);
+  });
+
+  it('throws when the token exchange returns no access_token', async () => {
+    const { fetch } = happyFetch({ token: { error: 'invalid_grant' } });
+    await expect(new HttpVeoTokenMinter({ fetch }).mint(COOKIE)).rejects.toThrow(/invalid_grant|token/i);
+  });
+});

--- a/apps/api/src/modules/veo-scraper/__tests__/VeoCookieSeeder.test.ts
+++ b/apps/api/src/modules/veo-scraper/__tests__/VeoCookieSeeder.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { pickSessionCookieHeader } from '../implementations/veo-cookie';
+import { VeoCookieSeeder } from '../implementations/VeoCookieSeeder';
+import type { IVeoAuthenticator, VeoSession } from '../interfaces';
+
+describe('pickSessionCookieHeader', () => {
+  it('keeps only _session* cookies and joins them as a header', () => {
+    const header = pickSessionCookieHeader([
+      { name: '_ga', value: 'x' },
+      { name: '_session', value: 'AAA' },
+      { name: 'ajs_user_id', value: 'y' },
+      { name: '_session.sig', value: 'BBB' },
+      { name: '_session.legacy', value: 'CCC' },
+    ]);
+    expect(header).toBe('_session=AAA; _session.sig=BBB; _session.legacy=CCC');
+  });
+
+  it('returns empty string when no session cookie is present', () => {
+    expect(pickSessionCookieHeader([{ name: '_ga', value: 'x' }])).toBe('');
+    expect(pickSessionCookieHeader([])).toBe('');
+  });
+});
+
+function fakeAuth(cookies: Array<{ name: string; value: string }>): {
+  auth: IVeoAuthenticator;
+  logout: any;
+} {
+  const logout = vi.fn(async () => {});
+  const session: VeoSession = { context: { cookies: vi.fn(async () => cookies) } };
+  const auth: IVeoAuthenticator = { login: vi.fn(async () => session), logout };
+  return { auth, logout };
+}
+
+describe('VeoCookieSeeder', () => {
+  it('logs in, extracts the _session cookie header, then logs out', async () => {
+    const { auth, logout } = fakeAuth([
+      { name: '_session', value: 'S1' },
+      { name: '_session.sig', value: 'S2' },
+      { name: '_ga', value: 'noise' },
+    ]);
+    const header = await new VeoCookieSeeder(auth).seed({ email: 'e', password: 'p' });
+    expect(header).toBe('_session=S1; _session.sig=S2');
+    expect(auth.login).toHaveBeenCalledWith({ email: 'e', password: 'p' });
+    expect(logout).toHaveBeenCalledTimes(1); // browser always closed
+  });
+
+  it('throws (and still logs out) when no session cookie is captured', async () => {
+    const { auth, logout } = fakeAuth([{ name: '_ga', value: 'noise' }]);
+    await expect(new VeoCookieSeeder(auth).seed({ email: 'e', password: 'p' })).rejects.toThrow(/session cookie/i);
+    expect(logout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/modules/veo-scraper/__tests__/veo-oidc.test.ts
+++ b/apps/api/src/modules/veo-scraper/__tests__/veo-oidc.test.ts
@@ -1,0 +1,82 @@
+import { createHash } from 'crypto';
+import { describe, it, expect } from 'vitest';
+
+import {
+  DEFAULT_VEO_OIDC,
+  generatePkce,
+  buildAuthorizeUrl,
+  extractCodeFromLocation,
+  extractClubSlug,
+} from '../implementations/veo-oidc';
+
+const b64url = (b: Buffer) =>
+  b.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+describe('generatePkce', () => {
+  it('produces a url-safe verifier of RFC-legal length', () => {
+    const { verifier } = generatePkce();
+    expect(verifier).toMatch(/^[A-Za-z0-9\-_]+$/);
+    expect(verifier.length).toBeGreaterThanOrEqual(43);
+    expect(verifier.length).toBeLessThanOrEqual(128);
+  });
+
+  it('challenge is BASE64URL(SHA256(verifier)) — S256', () => {
+    const { verifier, challenge } = generatePkce();
+    expect(challenge).toBe(b64url(createHash('sha256').update(verifier).digest()));
+    expect(challenge).toMatch(/^[A-Za-z0-9\-_]+$/);
+    expect(challenge).not.toContain('=');
+  });
+
+  it('is random per call', () => {
+    expect(generatePkce().verifier).not.toBe(generatePkce().verifier);
+  });
+});
+
+describe('buildAuthorizeUrl', () => {
+  it('encodes all required OIDC + PKCE params', () => {
+    const url = new URL(
+      buildAuthorizeUrl(DEFAULT_VEO_OIDC, { challenge: 'CHAL', state: 'st8' })
+    );
+    expect(url.origin + url.pathname).toBe(DEFAULT_VEO_OIDC.authorizeUrl);
+    const p = url.searchParams;
+    expect(p.get('client_id')).toBe(DEFAULT_VEO_OIDC.clientId);
+    expect(p.get('redirect_uri')).toBe(DEFAULT_VEO_OIDC.redirectUri);
+    expect(p.get('response_type')).toBe('code');
+    expect(p.get('scope')).toBe(DEFAULT_VEO_OIDC.scope);
+    expect(p.get('code_challenge')).toBe('CHAL');
+    expect(p.get('code_challenge_method')).toBe('S256');
+    expect(p.get('state')).toBe('st8');
+  });
+});
+
+describe('extractCodeFromLocation', () => {
+  it('reads the code from an absolute redirect', () => {
+    expect(
+      extractCodeFromLocation('https://app.veo.co/signin-redirect/?code=ABC123&state=x')
+    ).toBe('ABC123');
+  });
+  it('reads the code from a relative redirect', () => {
+    expect(extractCodeFromLocation('/signin-redirect/?state=x&code=Z9')).toBe('Z9');
+  });
+  it('returns null when there is no code (e.g. an error redirect)', () => {
+    expect(extractCodeFromLocation('/error.html?errorMessage=bad')).toBeNull();
+    expect(extractCodeFromLocation('')).toBeNull();
+    expect(extractCodeFromLocation(null)).toBeNull();
+  });
+});
+
+describe('extractClubSlug', () => {
+  it('pulls the club slug from a diagnostics URL', () => {
+    expect(
+      extractClubSlug('https://app.veo.co/clubs/noctusoft-inc/live/streaming-diagnostics')
+    ).toBe('noctusoft-inc');
+  });
+  it('pulls the club slug from a bare live URL', () => {
+    expect(extractClubSlug('https://app.veo.co/clubs/club-america-tarrant-county/live')).toBe(
+      'club-america-tarrant-county'
+    );
+  });
+  it('returns null when there is no club segment', () => {
+    expect(extractClubSlug('https://app.veo.co/recordings')).toBeNull();
+  });
+});

--- a/apps/api/src/modules/veo-scraper/implementations/CachingVeoTokenProvider.ts
+++ b/apps/api/src/modules/veo-scraper/implementations/CachingVeoTokenProvider.ts
@@ -1,0 +1,52 @@
+/**
+ * CachingVeoTokenProvider — hands out a valid Veo access token, minting a new one
+ * only when the cached token is missing or within `safetyMarginSec` of expiry.
+ * Keeps the per-poll cost to a couple of HTTP calls at most once an hour.
+ */
+
+import type {
+  IVeoAccessTokenProvider,
+  IVeoTokenMinter,
+} from '../interfaces';
+
+export interface CachingVeoTokenProviderDeps {
+  minter: IVeoTokenMinter;
+  sessionCookie: string;
+  /** Epoch millis clock (injectable for tests). Defaults to Date.now. */
+  now?: () => number;
+  /** Re-mint this many seconds before actual expiry. Default 60s. */
+  safetyMarginSec?: number;
+}
+
+export class CachingVeoTokenProvider implements IVeoAccessTokenProvider {
+  private readonly minter: IVeoTokenMinter;
+  private readonly sessionCookie: string;
+  private readonly now: () => number;
+  private readonly marginMs: number;
+
+  private cached: { token: string; expiresAtMs: number } | null = null;
+
+  constructor(deps: CachingVeoTokenProviderDeps) {
+    this.minter = deps.minter;
+    this.sessionCookie = deps.sessionCookie;
+    this.now = deps.now ?? Date.now;
+    this.marginMs = (deps.safetyMarginSec ?? 60) * 1000;
+  }
+
+  /** Drop the cached token so the next call re-mints (e.g. after a 401). */
+  invalidate(): void {
+    this.cached = null;
+  }
+
+  async getAccessToken(): Promise<string> {
+    if (this.cached && this.now() < this.cached.expiresAtMs - this.marginMs) {
+      return this.cached.token;
+    }
+    const minted = await this.minter.mint(this.sessionCookie);
+    this.cached = {
+      token: minted.accessToken,
+      expiresAtMs: this.now() + minted.expiresInSec * 1000,
+    };
+    return minted.accessToken;
+  }
+}

--- a/apps/api/src/modules/veo-scraper/implementations/HttpVeoAuthenticator.ts
+++ b/apps/api/src/modules/veo-scraper/implementations/HttpVeoAuthenticator.ts
@@ -1,0 +1,57 @@
+/**
+ * HttpVeoAuthenticator — the browser-free IVeoAuthenticator.
+ *
+ * "Login" here means: bind a token provider to the seeded `_session` cookie.
+ * No browser, no email/password at runtime — the cookie is the credential.
+ * The returned session carries the provider for the scraper to use.
+ */
+
+import {
+  type FetchLike,
+  type IVeoAccessTokenProvider,
+  type IVeoAuthenticator,
+  type VeoCredentials,
+  type VeoSession,
+} from '../interfaces';
+
+import { CachingVeoTokenProvider } from './CachingVeoTokenProvider';
+import { HttpVeoTokenMinter } from './HttpVeoTokenMinter';
+
+/** Provider that can also be invalidated (for the scraper's 401 retry). */
+export type InvalidatableTokenProvider = IVeoAccessTokenProvider & { invalidate?: () => void };
+
+export interface HttpVeoAuthenticatorDeps {
+  /** Build a token provider for a seeded cookie (injectable for tests). */
+  createTokenProvider?: (sessionCookie: string) => InvalidatableTokenProvider;
+}
+
+function defaultCreateTokenProvider(sessionCookie: string): InvalidatableTokenProvider {
+  const fetch = globalThis.fetch as unknown as FetchLike;
+  return new CachingVeoTokenProvider({
+    minter: new HttpVeoTokenMinter({ fetch }),
+    sessionCookie,
+  });
+}
+
+export class HttpVeoAuthenticator implements IVeoAuthenticator {
+  private readonly createTokenProvider: (sessionCookie: string) => InvalidatableTokenProvider;
+
+  constructor(deps: HttpVeoAuthenticatorDeps = {}) {
+    this.createTokenProvider = deps.createTokenProvider ?? defaultCreateTokenProvider;
+  }
+
+  async login(credentials: VeoCredentials): Promise<VeoSession> {
+    const cookie = credentials.sessionCookie?.trim();
+    if (!cookie) {
+      throw new Error(
+        'HttpVeoAuthenticator requires a seeded session cookie (VeoIntegration.veoSessionCookie). Reconnect Veo to seed one.'
+      );
+    }
+    const provider = this.createTokenProvider(cookie);
+    return { context: { provider } };
+  }
+
+  async logout(_session: VeoSession): Promise<void> {
+    // Nothing to close — the HTTP client holds no browser/socket.
+  }
+}

--- a/apps/api/src/modules/veo-scraper/implementations/HttpVeoStreamHistoryClient.ts
+++ b/apps/api/src/modules/veo-scraper/implementations/HttpVeoStreamHistoryClient.ts
@@ -1,0 +1,53 @@
+/**
+ * HttpVeoStreamHistoryClient — read a club's live streams over pure HTTP.
+ *
+ *   GET app.veo.co/api/v2/live/stream-history/clubs/<club>/stream-history  (Bearer)
+ *
+ * Each entry's `additional_info.broadcast_link` is the stream.mux.com URL. We
+ * map + keep only currently-live rows (reusing the tested pure helpers).
+ */
+
+import {
+  VeoSessionExpiredError,
+  type FetchLike,
+  type IVeoStreamHistoryClient,
+  type VeoMatchRow,
+  type VeoOidcConfig,
+} from '../interfaces';
+
+import { mapStreamHistoryToRows, isLiveRow, type StreamHistoryResponse } from './PlaywrightVeoLiveApiScraper';
+import { DEFAULT_VEO_OIDC } from './veo-oidc';
+
+export interface HttpVeoStreamHistoryClientDeps {
+  fetch: FetchLike;
+  config?: VeoOidcConfig;
+}
+
+export class HttpVeoStreamHistoryClient implements IVeoStreamHistoryClient {
+  private readonly fetch: FetchLike;
+  private readonly cfg: VeoOidcConfig;
+
+  constructor(deps: HttpVeoStreamHistoryClientDeps) {
+    this.fetch = deps.fetch;
+    this.cfg = deps.config ?? DEFAULT_VEO_OIDC;
+  }
+
+  async fetchLiveStreams(accessToken: string, clubSlug: string): Promise<VeoMatchRow[]> {
+    const url = `${this.cfg.streamHistoryBase}/${clubSlug}/stream-history`;
+    const res = await this.fetch(url, {
+      method: 'GET',
+      headers: { Authorization: `Bearer ${accessToken}`, Accept: 'application/json' },
+    });
+
+    // 401 → the access token is stale; surface so the caller re-mints.
+    if (res.status === 401) throw new VeoSessionExpiredError('Veo access token rejected (401)');
+    // 403 → this login has no diagnostics rights on that club; not an error, just no live streams.
+    if (res.status === 403) return [];
+    if (res.status < 200 || res.status >= 300) {
+      throw new Error(`Veo stream-history failed for ${clubSlug}: HTTP ${res.status}`);
+    }
+
+    const data = (await res.json().catch(() => null)) as StreamHistoryResponse | null;
+    return mapStreamHistoryToRows(data).filter(isLiveRow);
+  }
+}

--- a/apps/api/src/modules/veo-scraper/implementations/HttpVeoStreamScraper.ts
+++ b/apps/api/src/modules/veo-scraper/implementations/HttpVeoStreamScraper.ts
@@ -1,0 +1,53 @@
+/**
+ * HttpVeoStreamScraper — the browser-free IVeoDiagnosticsScraper.
+ *
+ * Reads the token provider off the session (put there by HttpVeoAuthenticator),
+ * derives the club slug from the diagnostics URL, and fetches live streams over
+ * pure HTTP. On a 401 (stale access token) it invalidates + re-mints once; if
+ * that also fails, the session cookie is truly dead and the error propagates.
+ */
+
+import {
+  VeoSessionExpiredError,
+  type IVeoDiagnosticsScraper,
+  type IVeoStreamHistoryClient,
+  type VeoMatchRow,
+  type VeoSession,
+} from '../interfaces';
+
+import type { InvalidatableTokenProvider } from './HttpVeoAuthenticator';
+import { extractClubSlug } from './veo-oidc';
+
+export interface HttpVeoStreamScraperDeps {
+  streamClient: IVeoStreamHistoryClient;
+}
+
+export class HttpVeoStreamScraper implements IVeoDiagnosticsScraper {
+  private readonly streamClient: IVeoStreamHistoryClient;
+
+  constructor(deps: HttpVeoStreamScraperDeps) {
+    this.streamClient = deps.streamClient;
+  }
+
+  async scrape(session: VeoSession, diagnosticsUrl: string): Promise<VeoMatchRow[]> {
+    const provider = (session.context as { provider?: InvalidatableTokenProvider }).provider;
+    if (!provider) throw new Error('HttpVeoStreamScraper: session has no token provider');
+
+    const clubSlug = extractClubSlug(diagnosticsUrl);
+    if (!clubSlug) throw new Error(`HttpVeoStreamScraper: no club slug in "${diagnosticsUrl}"`);
+
+    const token = await provider.getAccessToken();
+    try {
+      return await this.streamClient.fetchLiveStreams(token, clubSlug);
+    } catch (err) {
+      // A 401 means the access token went stale; drop it, re-mint, and retry once.
+      // If the re-mint itself fails (authorize yields no code), the cookie is dead → propagate.
+      if (err instanceof VeoSessionExpiredError && provider.invalidate) {
+        provider.invalidate();
+        const fresh = await provider.getAccessToken();
+        return await this.streamClient.fetchLiveStreams(fresh, clubSlug);
+      }
+      throw err;
+    }
+  }
+}

--- a/apps/api/src/modules/veo-scraper/implementations/HttpVeoTokenMinter.ts
+++ b/apps/api/src/modules/veo-scraper/implementations/HttpVeoTokenMinter.ts
@@ -1,0 +1,82 @@
+/**
+ * HttpVeoTokenMinter — mint a Veo access token from a seeded `_session` cookie,
+ * over pure HTTP (no browser).
+ *
+ *   GET  authorize (Cookie: _session…, PKCE) --303--> Location carries ?code=
+ *   POST token     (code + code_verifier, public client) ------------> access_token
+ *
+ * If authorize returns no code, the session cookie is dead → VeoSessionExpiredError
+ * (the owner must re-seed via a one-time browser login).
+ */
+
+import {
+  VeoSessionExpiredError,
+  type FetchLike,
+  type IVeoTokenMinter,
+  type MintedToken,
+  type VeoOidcConfig,
+} from '../interfaces';
+
+import {
+  DEFAULT_VEO_OIDC,
+  buildAuthorizeUrl,
+  extractCodeFromLocation,
+  generatePkce,
+} from './veo-oidc';
+
+export interface HttpVeoTokenMinterDeps {
+  fetch: FetchLike;
+  config?: VeoOidcConfig;
+  /** State generator (injectable for determinism in tests). */
+  makeState?: () => string;
+}
+
+export class HttpVeoTokenMinter implements IVeoTokenMinter {
+  private readonly fetch: FetchLike;
+  private readonly cfg: VeoOidcConfig;
+  private readonly makeState: () => string;
+
+  constructor(deps: HttpVeoTokenMinterDeps) {
+    this.fetch = deps.fetch;
+    this.cfg = deps.config ?? DEFAULT_VEO_OIDC;
+    this.makeState = deps.makeState ?? (() => `s${Date.now().toString(36)}${Math.floor(Math.random() * 1e6).toString(36)}`);
+  }
+
+  async mint(sessionCookie: string): Promise<MintedToken> {
+    const { verifier, challenge } = generatePkce();
+    const authorizeUrl = buildAuthorizeUrl(this.cfg, { challenge, state: this.makeState() });
+
+    const authRes = await this.fetch(authorizeUrl, {
+      method: 'GET',
+      headers: { Cookie: sessionCookie },
+      redirect: 'manual',
+    });
+    const code = extractCodeFromLocation(authRes.headers.get('location'));
+    if (!code) {
+      throw new VeoSessionExpiredError();
+    }
+
+    const tokenRes = await this.fetch(this.cfg.tokenUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: this.cfg.redirectUri,
+        client_id: this.cfg.clientId,
+        code_verifier: verifier,
+      }).toString(),
+    });
+
+    const body = (await tokenRes.json().catch(() => null)) as
+      | { access_token?: string; expires_in?: number; error?: string; error_description?: string }
+      | null;
+
+    if (!body?.access_token) {
+      const detail = body?.error_description || body?.error || `status ${tokenRes.status}`;
+      throw new Error(`Veo token exchange failed: ${detail}`);
+    }
+
+    return { accessToken: body.access_token, expiresInSec: body.expires_in ?? 3600 };
+  }
+}

--- a/apps/api/src/modules/veo-scraper/implementations/VeoCookieSeeder.ts
+++ b/apps/api/src/modules/veo-scraper/implementations/VeoCookieSeeder.ts
@@ -1,0 +1,36 @@
+/**
+ * VeoCookieSeeder — the ONE-TIME browser step that mints the durable credential.
+ *
+ * Logs in via the (browser) authenticator, extracts the `auth.veo.co` `_session`
+ * cookie header, and returns it to be stored encrypted on VeoIntegration. After
+ * this, the runtime is pure HTTP (see HttpVeoAuthenticator / HttpVeoTokenMinter).
+ * Runs off the hot path — locally or in a dedicated seeding step, so Chromium
+ * never needs to be in the production request path.
+ */
+
+import type { IVeoAuthenticator, VeoCredentials } from '../interfaces';
+
+import { pickSessionCookieHeader, type CookiePair } from './veo-cookie';
+
+interface CookieReadableContext {
+  cookies(url: string): Promise<CookiePair[]>;
+}
+
+export class VeoCookieSeeder {
+  constructor(private readonly authenticator: IVeoAuthenticator) {}
+
+  async seed(credentials: VeoCredentials): Promise<string> {
+    const session = await this.authenticator.login(credentials);
+    try {
+      const ctx = session.context as CookieReadableContext;
+      const cookies = await ctx.cookies('https://auth.veo.co');
+      const header = pickSessionCookieHeader(cookies);
+      if (!header) {
+        throw new Error('VeoCookieSeeder: no _session cookie captured after login');
+      }
+      return header;
+    } finally {
+      await this.authenticator.logout(session);
+    }
+  }
+}

--- a/apps/api/src/modules/veo-scraper/implementations/veo-cookie.ts
+++ b/apps/api/src/modules/veo-scraper/implementations/veo-cookie.ts
@@ -1,0 +1,17 @@
+/**
+ * Pure helper: reduce a cookie jar to the `auth.veo.co` `_session*` header that
+ * is the durable credential for the browser-free connector.
+ */
+
+export interface CookiePair {
+  name: string;
+  value: string;
+}
+
+/** Join only the `_session*` cookies into a "name=value; …" Cookie header. */
+export function pickSessionCookieHeader(cookies: CookiePair[]): string {
+  return cookies
+    .filter((c) => c.name.startsWith('_session'))
+    .map((c) => `${c.name}=${c.value}`)
+    .join('; ');
+}

--- a/apps/api/src/modules/veo-scraper/implementations/veo-oidc.ts
+++ b/apps/api/src/modules/veo-scraper/implementations/veo-oidc.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure OIDC helpers for the browser-free Veo client.
+ *
+ * Veo's auth is standard OIDC (node-oidc-provider at auth.veo.co):
+ * authorization_code + PKCE(S256), public client (no secret). These functions
+ * are side-effect-free (crypto only) so they unit-test without any network.
+ */
+
+import { createHash, randomBytes } from 'crypto';
+
+import type { VeoOidcConfig } from '../interfaces';
+
+/** Discovered Veo OIDC client config (see veo-integration-plan memory, 2026-08-12). */
+export const DEFAULT_VEO_OIDC: VeoOidcConfig = {
+  clientId: 'IzRQtXQ07V7n8uBtpTHzi',
+  redirectUri: 'https://app.veo.co/signin-redirect/',
+  authorizeUrl: 'https://auth.veo.co/oidc/auth',
+  tokenUrl: 'https://auth.veo.co/oidc/token',
+  streamHistoryBase: 'https://app.veo.co/api/v2/live/stream-history/clubs',
+  // The SPA uses "openid email phone address profile"; "openid" alone is enough
+  // for the stream-history API and keeps the token minimal.
+  scope: 'openid',
+};
+
+const base64url = (buf: Buffer): string =>
+  buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+
+export interface Pkce {
+  verifier: string;
+  challenge: string;
+}
+
+/** Generate a PKCE verifier + S256 challenge (RFC 7636). */
+export function generatePkce(): Pkce {
+  const verifier = base64url(randomBytes(32)); // 43 url-safe chars
+  const challenge = base64url(createHash('sha256').update(verifier).digest());
+  return { verifier, challenge };
+}
+
+/** Build the OIDC authorization URL for the code+PKCE flow. */
+export function buildAuthorizeUrl(
+  cfg: VeoOidcConfig,
+  opts: { challenge: string; state: string }
+): string {
+  const p = new URLSearchParams({
+    client_id: cfg.clientId,
+    redirect_uri: cfg.redirectUri,
+    response_type: 'code',
+    scope: cfg.scope,
+    code_challenge: opts.challenge,
+    code_challenge_method: 'S256',
+    state: opts.state,
+  });
+  return `${cfg.authorizeUrl}?${p.toString()}`;
+}
+
+/** Extract the `code` query param from an authorize redirect `Location` header. */
+export function extractCodeFromLocation(location: string | null | undefined): string | null {
+  if (!location) return null;
+  try {
+    // Base lets us parse relative Locations ("/signin-redirect/?code=…").
+    return new URL(location, 'https://app.veo.co').searchParams.get('code');
+  } catch {
+    return null;
+  }
+}
+
+/** Pull the club slug out of a diagnostics or live URL (…/clubs/<slug>/…). */
+export function extractClubSlug(url: string): string | null {
+  const m = url.match(/\/clubs\/([^/]+)/);
+  return m ? m[1] : null;
+}

--- a/apps/api/src/modules/veo-scraper/index.ts
+++ b/apps/api/src/modules/veo-scraper/index.ts
@@ -14,22 +14,62 @@ import { PlaywrightVeoLiveApiScraper } from './implementations/PlaywrightVeoLive
 import { FuseStreamMatcher } from './implementations/FuseStreamMatcher';
 import { PrismaStreamUpdater } from './implementations/PrismaStreamUpdater';
 import { PrismaVeoCandidateReader } from './implementations/PrismaVeoCandidateReader';
-import type { ScraperConfig, ScrapeRunResult, PollingConfig } from './interfaces';
+// Browser-free (pure HTTP) path — see veo-integration-plan memory (2026-08-12).
+import { HttpVeoAuthenticator } from './implementations/HttpVeoAuthenticator';
+import { HttpVeoStreamScraper } from './implementations/HttpVeoStreamScraper';
+import { HttpVeoStreamHistoryClient } from './implementations/HttpVeoStreamHistoryClient';
+import type {
+  FetchLike,
+  IVeoAuthenticator,
+  IVeoDiagnosticsScraper,
+  ScraperConfig,
+  ScrapeRunResult,
+  PollingConfig,
+} from './interfaces';
 
 export type { ScraperConfig, ScrapeRunResult, PollingConfig } from './interfaces';
 export { VeoScraperOrchestrator } from './VeoScraperOrchestrator';
 export { VeoPollingOrchestrator } from './VeoPollingOrchestrator';
 export { VeoPollingSessionManager } from './VeoPollingSessionManager';
 
+export { VeoCookieSeeder } from './implementations/VeoCookieSeeder';
+export { pickSessionCookieHeader } from './implementations/veo-cookie';
+export { HttpVeoAuthenticator } from './implementations/HttpVeoAuthenticator';
+export { HttpVeoStreamScraper } from './implementations/HttpVeoStreamScraper';
+export { HttpVeoStreamHistoryClient } from './implementations/HttpVeoStreamHistoryClient';
+
 export const veoPollingSessionManager = new VeoPollingSessionManager();
 
 /**
- * Create orchestrator with default implementations (Playwright, Prisma, Fuse).
+ * Select the auth + scrape pair. Browser-free HTTP path when `VEO_HTTP_MODE`
+ * is 'true' (needs a seeded `credentials.sessionCookie`); otherwise the
+ * Playwright path. The HTTP path removes Chromium from the hot path.
  */
-export function createVeoScraperOrchestrator(): VeoScraperOrchestrator {
+function buildVeoAuthAndScraper(httpMode?: boolean): { authenticator: IVeoAuthenticator; scraper: IVeoDiagnosticsScraper } {
+  const useHttp = httpMode ?? process.env.VEO_HTTP_MODE === 'true';
+  if (useHttp) {
+    return {
+      authenticator: new HttpVeoAuthenticator(),
+      scraper: new HttpVeoStreamScraper({
+        streamClient: new HttpVeoStreamHistoryClient({ fetch: globalThis.fetch as unknown as FetchLike }),
+      }),
+    };
+  }
+  return {
+    authenticator: new PlaywrightVeoAuthenticator(),
+    scraper: new PlaywrightVeoLiveApiScraper(),
+  };
+}
+
+/**
+ * Create orchestrator with default implementations (Prisma, Fuse) + the
+ * env-selected auth/scrape pair (Playwright or browser-free HTTP).
+ */
+export function createVeoScraperOrchestrator(opts?: { httpMode?: boolean }): VeoScraperOrchestrator {
+  const { authenticator, scraper } = buildVeoAuthAndScraper(opts?.httpMode);
   return new VeoScraperOrchestrator(
-    new PlaywrightVeoAuthenticator(),
-    new PlaywrightVeoLiveApiScraper(),
+    authenticator,
+    scraper,
     new FuseStreamMatcher({ minConfidence: 0.7 }),
     new PrismaStreamUpdater(prisma),
     new PrismaVeoCandidateReader(prisma)
@@ -39,10 +79,11 @@ export function createVeoScraperOrchestrator(): VeoScraperOrchestrator {
 /**
  * Create polling orchestrator with default implementations (session-cached).
  */
-export function createVeoPollingOrchestrator(): VeoPollingOrchestrator {
+export function createVeoPollingOrchestrator(opts?: { httpMode?: boolean }): VeoPollingOrchestrator {
+  const { authenticator, scraper } = buildVeoAuthAndScraper(opts?.httpMode);
   return new VeoPollingOrchestrator(
-    new PlaywrightVeoAuthenticator(),
-    new PlaywrightVeoLiveApiScraper(),
+    authenticator,
+    scraper,
     new FuseStreamMatcher({ minConfidence: 0.7 }),
     new PrismaStreamUpdater(prisma),
     new PrismaVeoCandidateReader(prisma)
@@ -69,7 +110,9 @@ export function getVeoScraperConfigFromEnv(): ScraperConfig {
   }
 
   return {
-    credentials: { email, password },
+    // sessionCookie (browser-free path) is optional; supplied via env for scripts
+    // or from VeoIntegration.veoSessionCookie by the job.
+    credentials: { email, password, sessionCookie: process.env.VEO_SESSION_COOKIE },
     diagnosticsUrl,
     ownerAccountId,
     minConfidence: 0.7,

--- a/apps/api/src/modules/veo-scraper/interfaces.ts
+++ b/apps/api/src/modules/veo-scraper/interfaces.ts
@@ -6,11 +6,77 @@
 export interface VeoCredentials {
   email: string;
   password: string;
+  /**
+   * A previously-seeded `auth.veo.co` `_session` cookie header (e.g.
+   * "_session=…; _session.sig=…"). When present, the HTTP client mints access
+   * tokens from it with no browser. Absent for the browser (Playwright) path.
+   */
+  sessionCookie?: string;
 }
 
 /** Authenticated browser context (Playwright BrowserContext at runtime). */
 export interface VeoSession {
   context: unknown;
+}
+
+// ── HTTP (browser-free) OIDC seams ───────────────────────────────────────────
+
+/** Static OIDC client config for Veo (public client; PKCE S256). */
+export interface VeoOidcConfig {
+  clientId: string;
+  redirectUri: string;
+  authorizeUrl: string;
+  tokenUrl: string;
+  streamHistoryBase: string;
+  scope: string;
+}
+
+/** A minted access token plus its lifetime in seconds. */
+export interface MintedToken {
+  accessToken: string;
+  expiresInSec: number;
+}
+
+/** Minimal HTTP response shape (satisfied by the global `fetch` Response). */
+export interface HttpResponse {
+  status: number;
+  headers: { get(name: string): string | null };
+  json(): Promise<unknown>;
+  text(): Promise<string>;
+}
+
+/** Minimal injectable fetch (satisfied by the global `fetch`). */
+export type FetchLike = (
+  url: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    redirect?: 'follow' | 'manual';
+  }
+) => Promise<HttpResponse>;
+
+/** Mint a Veo access token from a seeded `_session` cookie (pure HTTP, no browser). */
+export interface IVeoTokenMinter {
+  mint(sessionCookie: string): Promise<MintedToken>;
+}
+
+/** Provide a valid access token, caching + re-minting as it expires. */
+export interface IVeoAccessTokenProvider {
+  getAccessToken(): Promise<string>;
+}
+
+/** Read a club's live stream rows given an access token (browser-free). */
+export interface IVeoStreamHistoryClient {
+  fetchLiveStreams(accessToken: string, clubSlug: string): Promise<VeoMatchRow[]>;
+}
+
+/** Raised when the seeded session cookie no longer mints tokens → owner must re-seed. */
+export class VeoSessionExpiredError extends Error {
+  constructor(message = 'Veo session cookie expired — reconnect required') {
+    super(message);
+    this.name = 'VeoSessionExpiredError';
+  }
 }
 
 export interface VeoMatchRow {

--- a/packages/data-model/prisma/migrations/20260812000000_add_veo_session_cookie/migration.sql
+++ b/packages/data-model/prisma/migrations/20260812000000_add_veo_session_cookie/migration.sql
@@ -1,0 +1,3 @@
+-- Browser-free Veo connector: store a seeded auth.veo.co `_session` cookie
+-- (encrypted) so the runtime mints access tokens over pure HTTP (no Chromium).
+ALTER TABLE "VeoIntegration" ADD COLUMN "veoSessionCookieEncrypted" TEXT;

--- a/packages/data-model/prisma/schema.prisma
+++ b/packages/data-model/prisma/schema.prisma
@@ -59,6 +59,9 @@ model VeoIntegration {
   veoEmail             String
   veoPasswordEncrypted String
   veoDiagnosticsUrl    String   @db.VarChar(2048)
+  // Browser-free path: a seeded auth.veo.co `_session` cookie header (encrypted).
+  // When present, the connector mints tokens over pure HTTP — no Chromium at runtime.
+  veoSessionCookieEncrypted String? @db.Text
   createdAt            DateTime @default(now())
   updatedAt            DateTime @updatedAt
 


### PR DESCRIPTION
## What
Removes **Chromium from the Veo hot path**. Veo auth is standard OIDC (PKCE, public client); a seeded `auth.veo.co` **`_session` cookie** is the durable credential, so every poll is pure HTTP:

```
_session cookie → authorize(PKCE) → token → GET stream-history → broadcast_link (stream.mux.com/…)
```

Proven end-to-end against live Veo (cookie-only, no browser). Measured: the session cookie stays valid **3h+ and counting**, so re-seeding is infrequent.

## Design (TDD + ISP — 32 new tests, 65/65 veo suite green, typecheck clean)
Small segregated units, each tested with injected `fetch`/clock:
- `veo-oidc.ts` — pure PKCE / authorize-URL / code+club extraction
- `HttpVeoTokenMinter` (`IVeoTokenMinter`) — cookie → access_token; no-code ⇒ `VeoSessionExpiredError`
- `HttpVeoStreamHistoryClient` (`IVeoStreamHistoryClient`) — Bearer GET; 401⇒expired, 403⇒[]
- `CachingVeoTokenProvider` (`IVeoAccessTokenProvider`) — cache + re-mint near expiry; `invalidate()`
- `HttpVeoAuthenticator` / `HttpVeoStreamScraper` — drop into the **existing** `IVeoAuthenticator` / `IVeoDiagnosticsScraper` seams, so the orchestrator, matcher, updater, cron, and polling are **unchanged** (pure substitution)
- `VeoCookieSeeder` + `scripts/seed-veo-session-cookie.ts` — one-time browser seed, **off the hot path**

## Wiring
- `VeoIntegration.veoSessionCookieEncrypted` (+ migration `20260812000000_add_veo_session_cookie`)
- Job decrypts the cookie → runs **HTTP mode per-integration**; Playwright only when no cookie (dev)
- Factory `createVeo*Orchestrator({ httpMode })`
- Verify script: `scripts/verify-veo-http.ts` (`COOKIE_FILE=… npx tsx …`)

## Rollout after merge
1. `seed-veo-session-cookie.ts` (locally, with Chromium) stores the encrypted cookie per env
2. Set `VEO_HTTP_MODE=true` on the api envs → cron/pull run pure HTTP
3. Prod never needs Chromium on the hot path

🤖 Generated with [Claude Code](https://claude.com/claude-code)