### PR TITLE
promote: shared multi-channel stream toolbar → PROD

### DIFF
--- a/apps/web/__tests__/e2e/multi-channel-poc.spec.ts
+++ b/apps/web/__tests__/e2e/multi-channel-poc.spec.ts
@@ -1,19 +1,31 @@
 /**
  * Multi-channel overlay PoC — E2E guarantee
  *
- * Two viewer instances share one stream. A change on Channel A must appear on B
- * (and the reverse path for confirm).
+ * Shared toolbar owns stream + sport + clock. Channel panels are viewers only.
  */
 
 import { test, expect } from '@playwright/test';
 
 const URL = '/demo/multi-channel';
+const DEFAULT_STREAM =
+  'https://stream.mux.com/VZtzUzGRv02OhRnZCxcNg49OilvolTqdnFLEqBsTwaxU.m3u8';
 
 test.describe('Multi-channel overlay PoC', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(URL);
     await page.getByTestId('channel-panel-a').waitFor({ state: 'visible' });
     await page.getByTestId('channel-panel-b').waitFor({ state: 'visible' });
+  });
+
+  test('stream input defaults to the Mux clip; sport lives only in the toolbar', async ({
+    page,
+  }) => {
+    await expect(page.getByTestId('input-stream-url')).toHaveValue(DEFAULT_STREAM);
+    await expect(page.getByTestId('multi-channel-toolbar').getByTestId('dropdown-sport')).toBeVisible();
+    await expect(page.getByTestId('channel-panel-a').getByTestId('dropdown-sport')).toHaveCount(0);
+    await expect(page.getByTestId('channel-panel-b').getByTestId('dropdown-sport')).toHaveCount(0);
+    await expect(page.getByTestId('vidstack-player-channel-a')).toBeVisible();
+    await expect(page.getByTestId('vidstack-player-channel-b')).toBeVisible();
   });
 
   test('both channels start on soccer 00:00', async ({ page }) => {
@@ -34,11 +46,11 @@ test.describe('Multi-channel overlay PoC', () => {
     );
   });
 
-  test('sport change on A appears on B (football 12:00)', async ({ page }) => {
+  test('shared sport change appears on both channels (football 12:00)', async ({ page }) => {
     const a = page.getByTestId('channel-panel-a');
     const b = page.getByTestId('channel-panel-b');
 
-    await a.getByTestId('dropdown-sport').selectOption('football');
+    await page.getByTestId('dropdown-sport').selectOption('football');
 
     await expect(a.getByTestId('mini-score-overlay').getByTestId('overlay-clock')).toHaveText(
       '12:00'
@@ -47,15 +59,14 @@ test.describe('Multi-channel overlay PoC', () => {
       '12:00'
     );
     await expect(b.getByTestId('mini-score-overlay').getByTestId('overlay-period')).toHaveText('Q1');
-    await expect(b.getByTestId('dropdown-sport')).toHaveValue('football');
+    await expect(page.getByTestId('dropdown-sport')).toHaveValue('football');
   });
 
-  test('clock start on A ticks down on B', async ({ page }) => {
-    const a = page.getByTestId('channel-panel-a');
+  test('shared clock start ticks down on both channels', async ({ page }) => {
     const b = page.getByTestId('channel-panel-b');
 
-    await a.getByTestId('dropdown-sport').selectOption('football');
-    await a.getByTestId('btn-clock-start').click();
+    await page.getByTestId('dropdown-sport').selectOption('football');
+    await page.getByTestId('btn-clock-start').click();
     await page.waitForTimeout(1500);
 
     const bClock = await b.getByTestId('mini-score-overlay').getByTestId('overlay-clock').textContent();
@@ -69,7 +80,7 @@ test.describe('Multi-channel overlay PoC', () => {
     const a = page.getByTestId('channel-panel-a');
     const b = page.getByTestId('channel-panel-b');
 
-    await a.getByTestId('dropdown-sport').selectOption('football');
+    await page.getByTestId('dropdown-sport').selectOption('football');
     await a.getByTestId('mini-score-overlay').getByTestId('btn-overlay-team-home').click();
 
     await expect(page.getByTestId('modal-report-event')).toBeVisible();
@@ -84,7 +95,6 @@ test.describe('Multi-channel overlay PoC', () => {
     await expect(a.getByTestId('debug-home-score')).toHaveText('0');
     await expect(b.getByTestId('debug-home-score')).toHaveText('0');
 
-    // Reporter cannot confirm; the other channel can
     await expect(a.getByTestId('btn-confirm-pending-event')).toHaveCount(0);
     await b.getByTestId('btn-confirm-pending-event').click();
 
@@ -93,11 +103,10 @@ test.describe('Multi-channel overlay PoC', () => {
     await expect(b.getByTestId('chip-pending-event')).toHaveCount(0);
   });
 
-  test('sport change on B appears on A', async ({ page }) => {
+  test('shared baseball overlay hides clock on both channels', async ({ page }) => {
     const a = page.getByTestId('channel-panel-a');
-    const b = page.getByTestId('channel-panel-b');
 
-    await b.getByTestId('dropdown-sport').selectOption('baseball');
+    await page.getByTestId('dropdown-sport').selectOption('baseball');
 
     await expect(a.getByTestId('mini-score-overlay').getByTestId('overlay-period')).toContainText(
       'Top'

--- a/apps/web/app/demo/multi-channel/page.tsx
+++ b/apps/web/app/demo/multi-channel/page.tsx
@@ -4,25 +4,13 @@
  * /demo/multi-channel
  *
  * Two viewer instances of the same stream on one screen.
- * Changes on Channel A (sport, clock, report) appear on Channel B, and vice versa.
+ * Stream URL, sport, and clock live in the shared toolbar — not per channel.
  */
 
 import { useRef } from 'react';
 import { SportOverlayViewer } from '@/components/demo/SportOverlayViewer';
+import { MultiChannelToolbar } from '@/components/demo/MultiChannelToolbar';
 import { DemoStreamRoom } from '@/lib/demo/DemoStreamRoom';
-import { useDemoStreamRoom } from '@/hooks/useDemoStreamRoom';
-
-function SharedActionBanner({ room }: { room: DemoStreamRoom }) {
-  const stream = useDemoStreamRoom(room, 'banner');
-  return (
-    <p
-      data-testid="shared-last-action"
-      className="rounded border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-100"
-    >
-      {stream.lastAction ?? 'Waiting for a change on either channel…'}
-    </p>
-  );
-}
 
 export default function MultiChannelDemoPage() {
   const roomRef = useRef<DemoStreamRoom | null>(null);
@@ -34,10 +22,10 @@ export default function MultiChannelDemoPage() {
       <header className="flex flex-col gap-2">
         <h1 className="text-white text-xl font-semibold">Multi-channel overlay PoC</h1>
         <p className="text-sm text-white/50">
-          Each panel is its own viewer on the same film. Report or start the clock on one side —
-          the other side should update immediately.
+          Load one stream, pick one sport overlay. Each panel is its own viewer — report or
+          confirm on one side and the other updates immediately.
         </p>
-        <SharedActionBanner room={room} />
+        <MultiChannelToolbar room={room} />
       </header>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
@@ -47,6 +35,8 @@ export default function MultiChannelDemoPage() {
             viewerId="channel-a"
             label="Channel A"
             panelTestId="channel-panel-a"
+            showProducerControls={false}
+            showPlayback
           />
         </section>
         <section className="rounded-xl border border-rose-500/40 bg-rose-950/30 p-3">
@@ -55,6 +45,8 @@ export default function MultiChannelDemoPage() {
             viewerId="channel-b"
             label="Channel B"
             panelTestId="channel-panel-b"
+            showProducerControls={false}
+            showPlayback
           />
         </section>
       </div>

--- a/apps/web/components/demo/DemoProducerControls.tsx
+++ b/apps/web/components/demo/DemoProducerControls.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+/**
+ * Shared sport + clock controls for overlay PoCs.
+ * One instance per page — not per channel.
+ */
+
+import { sportRegistry } from '@fieldview/data-model';
+import type { UseDemoStreamRoomReturn } from '@/hooks/useDemoStreamRoom';
+
+export interface DemoProducerControlsProps {
+  stream: UseDemoStreamRoomReturn;
+  selectId?: string;
+}
+
+export function DemoProducerControls({
+  stream,
+  selectId = 'sport-select',
+}: DemoProducerControlsProps) {
+  const sports = sportRegistry.listSports();
+
+  return (
+    <div className="flex flex-wrap items-end gap-3" data-testid="demo-producer-controls">
+      <div className="flex flex-col gap-1">
+        <label htmlFor={selectId} className="text-xs text-white/60">
+          Sport overlay
+        </label>
+        <select
+          id={selectId}
+          data-testid="dropdown-sport"
+          value={stream.sportId}
+          onChange={(e) => stream.setSport(e.target.value)}
+          className="rounded border border-white/20 bg-white/10 px-2 py-1.5 text-sm text-white"
+        >
+          {sports.map((s) => (
+            <option key={s.id} value={s.id}>
+              {s.displayName}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex items-end gap-2">
+        {stream.clockMode !== 'none' && (
+          <>
+            <button
+              type="button"
+              data-testid="btn-clock-start"
+              onClick={stream.startClock}
+              className="rounded bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-500"
+            >
+              ▶ Start
+            </button>
+            <button
+              type="button"
+              data-testid="btn-clock-pause"
+              onClick={stream.pauseClock}
+              className="rounded bg-amber-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-amber-500"
+            >
+              ⏸ Pause
+            </button>
+          </>
+        )}
+        <button
+          type="button"
+          data-testid="btn-clock-reset"
+          onClick={stream.resetClock}
+          className="rounded bg-slate-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-500"
+        >
+          ↺ Reset
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/demo/MultiChannelToolbar.tsx
+++ b/apps/web/components/demo/MultiChannelToolbar.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+/**
+ * Shared header for /demo/multi-channel: stream URL + one sport/clock overlay.
+ */
+
+import { FormEvent, useState } from 'react';
+import { sportRegistry } from '@fieldview/data-model';
+import { DemoProducerControls } from '@/components/demo/DemoProducerControls';
+import { useDemoStreamRoom } from '@/hooks/useDemoStreamRoom';
+import type { DemoStreamRoom } from '@/lib/demo/DemoStreamRoom';
+import { DEFAULT_DEMO_STREAM, loadDemoPlayback } from '@/lib/demo/resolveDemoStream';
+
+export function MultiChannelToolbar({ room }: { room: DemoStreamRoom }) {
+  const stream = useDemoStreamRoom(room, 'producer');
+  const [input, setInput] = useState(DEFAULT_DEMO_STREAM);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleLoad(e: FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      const loaded = await loadDemoPlayback(input);
+      stream.setPlaybackSrc(loaded.src);
+      if (loaded.sportId) {
+        const known = sportRegistry.listSports().some((s) => s.id === loaded.sportId);
+        if (known) stream.setSport(loaded.sportId);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not load stream');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3" data-testid="multi-channel-toolbar">
+      <form
+        data-testid="form-load-stream"
+        onSubmit={handleLoad}
+        className="flex flex-col gap-2 sm:flex-row sm:items-end"
+      >
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <label htmlFor="input-stream-url" className="text-xs text-white/60">
+            Stream URL or FieldView slug
+          </label>
+          <input
+            id="input-stream-url"
+            data-testid="input-stream-url"
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder={DEFAULT_DEMO_STREAM}
+            aria-describedby={error ? 'error-stream-url' : undefined}
+            className="w-full rounded border border-white/20 bg-white/10 px-3 py-1.5 text-sm text-white placeholder:text-white/30"
+          />
+        </div>
+        <button
+          type="submit"
+          data-testid="btn-load-stream"
+          data-loading={loading}
+          disabled={loading}
+          aria-label="Load stream into both channels"
+          className="rounded bg-sky-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-sky-500 disabled:opacity-50"
+        >
+          {loading ? 'Loading…' : 'Load'}
+        </button>
+      </form>
+      {error && (
+        <p id="error-stream-url" data-testid="error-stream-url" role="alert" className="text-sm text-red-400">
+          {error}
+        </p>
+      )}
+
+      <DemoProducerControls stream={stream} selectId="sport-select-producer" />
+
+      <p
+        data-testid="shared-last-action"
+        className="rounded border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-100"
+      >
+        {stream.lastAction ?? 'Waiting for a change on either channel…'}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/components/demo/SportOverlayViewer.tsx
+++ b/apps/web/components/demo/SportOverlayViewer.tsx
@@ -6,10 +6,11 @@
  */
 
 import { useState } from 'react';
-import { sportRegistry } from '@fieldview/data-model';
 import { MiniScoreOverlay } from '@/components/v2/scoreboard/MiniScoreOverlay';
 import { CompactScoreBar } from '@/components/v2/scoreboard/CompactScoreBar';
 import { ReportEventSheet } from '@/components/v2/chat/ReportEventSheet';
+import { VidstackPlayer } from '@/components/v2/video/VidstackPlayer';
+import { DemoProducerControls } from '@/components/demo/DemoProducerControls';
 import { useDemoStreamRoom } from '@/hooks/useDemoStreamRoom';
 import type { DemoStreamRoom } from '@/lib/demo/DemoStreamRoom';
 
@@ -20,6 +21,10 @@ export interface SportOverlayViewerProps {
   viewerId: string;
   label?: string;
   panelTestId?: string;
+  /** Sport + clock. Off for multi-channel (those live in the shared toolbar). */
+  showProducerControls?: boolean;
+  /** HLS player under the overlay. Off on the single-channel E2E page. */
+  showPlayback?: boolean;
 }
 
 export function SportOverlayViewer({
@@ -27,12 +32,13 @@ export function SportOverlayViewer({
   viewerId,
   label,
   panelTestId,
+  showProducerControls = true,
+  showPlayback = false,
 }: SportOverlayViewerProps) {
   const stream = useDemoStreamRoom(room, viewerId);
   const [sheetTarget, setSheetTarget] = useState<SheetTarget>(null);
   const [isExpanded, setIsExpanded] = useState(false);
 
-  const sports = sportRegistry.listSports();
   const homeTeam = { name: 'Home', score: stream.homeScore, color: '#3B82F6' };
   const awayTeam = { name: 'Away', score: stream.awayScore, color: '#EF4444' };
 
@@ -56,10 +62,7 @@ export function SportOverlayViewer({
   };
 
   return (
-    <div
-      className="flex flex-col gap-3"
-      data-testid={panelTestId}
-    >
+    <div className="flex flex-col gap-3" data-testid={panelTestId}>
       {label && (
         <div className="flex items-center justify-between gap-2">
           <span
@@ -74,74 +77,36 @@ export function SportOverlayViewer({
         </div>
       )}
 
-      <div className="flex flex-wrap items-center gap-3" data-testid="demo-controls">
-        <div className="flex flex-col gap-1">
-          <label htmlFor={`sport-select-${viewerId}`} className="text-xs text-white/60">
-            Sport
-          </label>
-          <select
-            id={`sport-select-${viewerId}`}
-            data-testid="dropdown-sport"
-            value={stream.sportId}
-            onChange={(e) => stream.setSport(e.target.value)}
-            className="rounded border border-white/20 bg-white/10 px-2 py-1.5 text-sm text-white"
-          >
-            {sports.map((s) => (
-              <option key={s.id} value={s.id}>
-                {s.displayName}
-              </option>
-            ))}
-          </select>
-        </div>
+      {showProducerControls && (
+        <DemoProducerControls stream={stream} selectId={`sport-select-${viewerId}`} />
+      )}
 
-        <div className="flex items-end gap-2">
-          {stream.clockMode !== 'none' && (
-            <>
-              <button
-                type="button"
-                data-testid="btn-clock-start"
-                onClick={stream.startClock}
-                className="rounded bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-emerald-500"
-              >
-                ▶ Start
-              </button>
-              <button
-                type="button"
-                data-testid="btn-clock-pause"
-                onClick={stream.pauseClock}
-                className="rounded bg-amber-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-amber-500"
-              >
-                ⏸ Pause
-              </button>
-            </>
-          )}
-          <button
-            type="button"
-            data-testid="btn-clock-reset"
-            onClick={stream.resetClock}
-            className="rounded bg-slate-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-500"
-          >
-            ↺ Reset
-          </button>
-        </div>
-
-        <div className="text-xs text-white/50">
-          Mode: <span data-testid="debug-clock-mode">{stream.clockMode}</span>
-          {' | '}
-          Clock: <span data-testid="debug-clock-time">{stream.time}</span>
-          {' | '}
-          Period: <span data-testid="debug-period">{stream.periodLabel}</span>
-          {' | '}
-          Score: <span data-testid="debug-home-score">{stream.homeScore}</span>
-          -
-          <span data-testid="debug-away-score">{stream.awayScore}</span>
-        </div>
+      <div className="text-xs text-white/50" data-testid="demo-controls">
+        Mode: <span data-testid="debug-clock-mode">{stream.clockMode}</span>
+        {' | '}
+        Clock: <span data-testid="debug-clock-time">{stream.time}</span>
+        {' | '}
+        Period: <span data-testid="debug-period">{stream.periodLabel}</span>
+        {' | '}
+        Score: <span data-testid="debug-home-score">{stream.homeScore}</span>
+        -
+        <span data-testid="debug-away-score">{stream.awayScore}</span>
       </div>
 
       <div className="relative w-full aspect-video bg-black rounded-lg overflow-hidden">
-        <div className="absolute inset-0 flex items-center justify-center text-white/20 text-sm select-none">
-          ▶ {label ?? 'Film'} (no video required)
-        </div>
+        {showPlayback ? (
+          <VidstackPlayer
+            src={stream.playbackSrc}
+            autoPlay
+            muted
+            className="h-full w-full"
+            data-testid={`vidstack-player-${viewerId}`}
+          />
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-center text-white/20 text-sm select-none">
+            ▶ {label ?? 'Film'} (no video required)
+          </div>
+        )}
 
         <MiniScoreOverlay
           homeTeam={homeTeam}
@@ -150,6 +115,7 @@ export function SportOverlayViewer({
           time={stream.hideClock ? undefined : stream.time}
           sportId={stream.sportId}
           crowdsource={overlayCrowdsource}
+          className="z-[40]"
         />
       </div>
 

--- a/apps/web/hooks/useDemoStreamRoom.ts
+++ b/apps/web/hooks/useDemoStreamRoom.ts
@@ -18,6 +18,7 @@ export interface UseDemoStreamRoomReturn extends DemoStreamSnapshot {
   periodLabel: string;
   clockMode: ClockMode;
   hideClock: boolean;
+  setPlaybackSrc(src: string): void;
   setSport(sportId: string): void;
   startClock(): void;
   pauseClock(): void;
@@ -59,6 +60,10 @@ export function useDemoStreamRoom(
     now: new Date(),
   });
 
+  const setPlaybackSrc = useCallback(
+    (src: string) => room.setPlaybackSrc(src, viewerId),
+    [room, viewerId]
+  );
   const setSport = useCallback((sportId: string) => room.setSport(sportId, viewerId), [room, viewerId]);
   const startClock = useCallback(() => room.startClock(viewerId), [room, viewerId]);
   const pauseClock = useCallback(() => room.pauseClock(viewerId), [room, viewerId]);
@@ -76,6 +81,7 @@ export function useDemoStreamRoom(
     periodLabel: periodLabeler.formatPeriod(snap.sportId, snap.period),
     clockMode,
     hideClock,
+    setPlaybackSrc,
     setSport,
     startClock,
     pauseClock,

--- a/apps/web/lib/demo/DemoStreamRoom.ts
+++ b/apps/web/lib/demo/DemoStreamRoom.ts
@@ -10,6 +10,7 @@ import {
   ScoreDeltaCalculator,
 } from '@fieldview/data-model';
 import type { ClockMode, EventCategory, ScoreAppliesTo } from '@fieldview/data-model';
+import { DEFAULT_DEMO_STREAM } from './resolveDemoStream';
 
 export type ClockStatus = 'stopped' | 'running' | 'paused';
 
@@ -28,6 +29,7 @@ export interface DemoPendingEvent {
 }
 
 export interface DemoStreamSnapshot {
+  playbackSrc: string;
   sportId: string;
   period: number;
   homeScore: number;
@@ -46,6 +48,7 @@ let nextEventId = 1;
 
 function initialSnapshot(): DemoStreamSnapshot {
   return {
+    playbackSrc: DEFAULT_DEMO_STREAM,
     sportId: 'soccer',
     period: 1,
     homeScore: 0,
@@ -75,6 +78,10 @@ export class DemoStreamRoom {
     return () => {
       this.listeners.delete(listener);
     };
+  }
+
+  setPlaybackSrc(src: string, actor: string): void {
+    this.commit({ playbackSrc: src }, `${actor} loaded stream`);
   }
 
   setSport(sportId: string, actor: string): void {

--- a/apps/web/lib/demo/__tests__/DemoStreamRoom.test.ts
+++ b/apps/web/lib/demo/__tests__/DemoStreamRoom.test.ts
@@ -27,6 +27,15 @@ describe('DemoStreamRoom', () => {
     expect(snap.clockStatus).toBe('stopped');
     expect(snap.clockSeconds).toBe(0);
     expect(snap.pendingEvent).toBeNull();
+    expect(snap.playbackSrc).toContain('stream.mux.com');
+  });
+
+  it('setPlaybackSrc notifies subscribers', () => {
+    const urls: string[] = [];
+    room.subscribe(() => urls.push(room.getSnapshot().playbackSrc));
+    room.setPlaybackSrc('https://example.com/live.m3u8', 'producer');
+    expect(room.getSnapshot().playbackSrc).toBe('https://example.com/live.m3u8');
+    expect(urls).toEqual(['https://example.com/live.m3u8']);
   });
 
   it('notifies every subscriber when sport changes', () => {

--- a/apps/web/lib/demo/__tests__/resolveDemoStream.test.ts
+++ b/apps/web/lib/demo/__tests__/resolveDemoStream.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  DEFAULT_DEMO_STREAM,
+  parseDemoStreamInput,
+  loadDemoPlayback,
+} from '../resolveDemoStream';
+
+describe('parseDemoStreamInput', () => {
+  it('empty input uses the default Mux stream', () => {
+    expect(parseDemoStreamInput('')).toEqual({ kind: 'url', url: DEFAULT_DEMO_STREAM });
+    expect(parseDemoStreamInput('   ')).toEqual({ kind: 'url', url: DEFAULT_DEMO_STREAM });
+  });
+
+  it('keeps an HLS URL as-is', () => {
+    const url = 'https://stream.mux.com/abc.m3u8';
+    expect(parseDemoStreamInput(url)).toEqual({ kind: 'url', url });
+  });
+
+  it('treats a FieldView slug as a slug', () => {
+    expect(parseDemoStreamInput('tchs')).toEqual({ kind: 'slug', slug: 'tchs' });
+    expect(parseDemoStreamInput('/direct/tchs')).toEqual({ kind: 'slug', slug: 'tchs' });
+  });
+
+  it('extracts a slug from a FieldView watch URL', () => {
+    expect(parseDemoStreamInput('https://fieldview.live/direct/tchs')).toEqual({
+      kind: 'slug',
+      slug: 'tchs',
+    });
+  });
+});
+
+describe('loadDemoPlayback', () => {
+  it('returns the URL without fetching', async () => {
+    const fetchFn = vi.fn();
+    const result = await loadDemoPlayback('https://stream.mux.com/x.m3u8', fetchFn);
+    expect(result.src).toBe('https://stream.mux.com/x.m3u8');
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('resolves a slug via bootstrap', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        streamUrl: 'https://stream.mux.com/live.m3u8',
+        page: { sport: 'football' },
+        title: 'TCHS',
+      }),
+    });
+    const result = await loadDemoPlayback('tchs', fetchFn);
+    expect(fetchFn).toHaveBeenCalledWith('http://localhost:4301/api/direct/tchs/bootstrap');
+    expect(result).toEqual({
+      src: 'https://stream.mux.com/live.m3u8',
+      sportId: 'football',
+      title: 'TCHS',
+    });
+  });
+
+  it('builds HLS from a top-level muxPlaybackId', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ muxPlaybackId: 'abc123', sport: 'soccer' }),
+    });
+    const result = await loadDemoPlayback('tchs', fetchFn);
+    expect(result.src).toBe('https://stream.mux.com/abc123.m3u8');
+    expect(result.sportId).toBe('soccer');
+  });
+});

--- a/apps/web/lib/demo/resolveDemoStream.ts
+++ b/apps/web/lib/demo/resolveDemoStream.ts
@@ -1,0 +1,87 @@
+/**
+ * Parse/load a playback source for the multi-channel overlay PoC.
+ * Accepts an HLS URL, a FieldView slug, or empty (default Mux clip).
+ */
+
+export const DEFAULT_DEMO_STREAM =
+  'https://stream.mux.com/VZtzUzGRv02OhRnZCxcNg49OilvolTqdnFLEqBsTwaxU.m3u8';
+
+export type ParsedDemoStream =
+  | { kind: 'url'; url: string }
+  | { kind: 'slug'; slug: string };
+
+function slugFromPath(pathname: string): string | null {
+  const match = pathname.match(/\/direct\/([^/?#]+)/i);
+  return match?.[1] ?? null;
+}
+
+export function parseDemoStreamInput(raw: string): ParsedDemoStream {
+  const trimmed = raw.trim();
+  if (!trimmed) return { kind: 'url', url: DEFAULT_DEMO_STREAM };
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    try {
+      const parsed = new URL(trimmed);
+      const slug = slugFromPath(parsed.pathname);
+      if (slug) return { kind: 'slug', slug };
+    } catch {
+      /* keep as URL */
+    }
+    return { kind: 'url', url: trimmed };
+  }
+
+  if (/\.m3u8(\?|#|$)/i.test(trimmed)) {
+    return { kind: 'url', url: trimmed };
+  }
+
+  const slug = trimmed.replace(/^\/direct\//i, '').replace(/^\//, '').split(/[/?#]/)[0];
+  if (!slug) return { kind: 'url', url: DEFAULT_DEMO_STREAM };
+  return { kind: 'slug', slug };
+}
+
+interface BootstrapPlayback {
+  streamUrl?: string | null;
+  muxPlaybackId?: string | null;
+  sport?: string;
+  title?: string;
+  page?: { sport?: string };
+  stream?: { url?: string | null; muxPlaybackId?: string | null };
+}
+
+function pickSrc(data: BootstrapPlayback): string | null {
+  if (data.streamUrl) return data.streamUrl;
+  if (data.stream?.url) return data.stream.url;
+  const muxId = data.muxPlaybackId ?? data.stream?.muxPlaybackId;
+  if (muxId) return `https://stream.mux.com/${muxId}.m3u8`;
+  return null;
+}
+
+export interface LoadedDemoPlayback {
+  src: string;
+  sportId?: string;
+  title?: string;
+}
+
+export async function loadDemoPlayback(
+  raw: string,
+  fetchFn: typeof fetch = fetch
+): Promise<LoadedDemoPlayback> {
+  const parsed = parseDemoStreamInput(raw);
+  if (parsed.kind === 'url') return { src: parsed.url };
+
+  const apiBase = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4301';
+  const res = await fetchFn(`${apiBase}/api/direct/${encodeURIComponent(parsed.slug)}/bootstrap`);
+  if (res.ok) {
+    const data = (await res.json()) as BootstrapPlayback;
+    const src = pickSrc(data);
+    if (src) {
+      return {
+        src,
+        sportId: data.page?.sport ?? data.sport,
+        title: data.title,
+      };
+    }
+  }
+
+  return { src: `https://stream.mux.com/${parsed.slug}.m3u8` };
+}


### PR DESCRIPTION
## Summary
- Promote release to production, including shared stream + sport controls on the multi-channel PoC (#212 via #213).

## Test plan
- [ ] Production web/api deploy successfully
- [ ] https://fieldview.live still loads
- [ ] https://fieldview.live/demo/multi-channel has one stream box and one sport overlay control


Made with [Cursor](https://cursor.com)